### PR TITLE
fix(retrieval): add dense fallback after empty hybrid retrieval

### DIFF
--- a/internal/service/nlp/retrieval.go
+++ b/internal/service/nlp/retrieval.go
@@ -25,6 +25,7 @@ import (
 	"ragflow/internal/engine"
 	"ragflow/internal/engine/types"
 	"ragflow/internal/entity/models"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -659,6 +660,8 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 				return nil, fmt.Errorf("GetVector failed: %w", err)
 			}
 
+			// Keep a pristine dense expression because connectors may rewrite its options.
+			denseTemplate := cloneDenseExpr(matchDense)
 			// Execute search with fusion
 			fusionExpr := buildRetrievalFusionExpr(s.docEngine.GetType(), knnTopK, req.VectorSimilarityWeight)
 
@@ -670,7 +673,11 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 			}
 
 			searchRequest.SelectFields = searchSrc
-			searchRequest.MatchExprs = []interface{}{matchText, matchDense, fusionExpr}
+			if matchText == nil {
+				searchRequest.MatchExprs = []interface{}{matchDense}
+			} else {
+				searchRequest.MatchExprs = []interface{}{matchText, matchDense, fusionExpr}
+			}
 			searchRequest.RankFeature = req.RankFeature
 
 			engineResult, err = s.docEngine.Search(ctx, searchRequest)
@@ -678,7 +685,7 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 				return nil, fmt.Errorf("search failed: %w", err)
 			}
 			// If result is empty, retry with relaxed conditions
-			if engineResult.Total == 0 {
+			if engineResult.Total == 0 && matchText != nil {
 				_, hasDocIDFilter := filters["doc_id"]
 				if hasDocIDFilter {
 					// When a doc_id filter is present (e.g. from metadata filter like era=960)
@@ -707,13 +714,27 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 					// This provides a second chance for queries that were too strict
 					// on the first attempt.
 					matchText, _ := GetQueryBuilder().Question(req.Question, "qa", 0.1)
-					matchDense.ExtraOptions["similarity"] = 0.17
-					searchRequest.MatchExprs = []interface{}{matchText, matchDense, fusionExpr}
+					relaxedDense := cloneDenseExpr(denseTemplate)
+					relaxedDense.ExtraOptions["similarity"] = 0.17
+					searchRequest.MatchExprs = []interface{}{matchText, relaxedDense, buildRetrievalFusionExpr(s.docEngine.GetType(), knnTopK, req.VectorSimilarityWeight)}
 					searchRequest.RankFeature = req.RankFeature
 
 					engineResult, err = s.docEngine.Search(ctx, searchRequest)
 					if err != nil {
 						return nil, fmt.Errorf("search retry failed: %w", err)
+					}
+					if engineResult.Total == 0 && matchText != nil {
+						// Intentionally recover only after both lexical attempts return zero.
+						common.Debug("Retrieval dense-only recovery triggered after empty hybrid retries")
+						denseFallback := cloneDenseExpr(denseTemplate)
+						denseFallback.ExtraOptions["similarity"] = 0.17
+						searchRequest.SelectFields = src
+						searchRequest.MatchExprs = []interface{}{denseFallback}
+						searchRequest.RankFeature = req.RankFeature
+						engineResult, err = s.docEngine.Search(ctx, searchRequest)
+						if err != nil {
+							return nil, fmt.Errorf("dense-only recovery failed: %w", err)
+						}
 					}
 				}
 			}
@@ -776,6 +797,39 @@ func (s *RetrievalService) Search(ctx context.Context, req *RetrievalSearchReque
 		Aggregation: aggregation,
 		IndexNames:  searchRequest.IndexNames,
 	}, nil
+}
+
+func cloneDenseExpr(src *types.MatchDenseExpr) *types.MatchDenseExpr {
+	clone := *src
+	clone.EmbeddingData = slices.Clone(src.EmbeddingData)
+	clone.ExtraOptions = make(map[string]interface{}, len(src.ExtraOptions))
+	for key, value := range src.ExtraOptions {
+		clone.ExtraOptions[key] = cloneDenseOption(value)
+	}
+	return &clone
+}
+
+func cloneDenseOption(value any) any {
+	switch value := value.(type) {
+	case map[string]any:
+		clone := make(map[string]any, len(value))
+		for key, item := range value {
+			clone[key] = cloneDenseOption(item)
+		}
+		return clone
+	case []any:
+		clone := make([]any, len(value))
+		for i, item := range value {
+			clone[i] = cloneDenseOption(item)
+		}
+		return clone
+	case []string:
+		return slices.Clone(value)
+	case []float64:
+		return slices.Clone(value)
+	default:
+		return value
+	}
 }
 
 // GetVector computes query vector and returns MatchDenseExpr for hybrid search

--- a/internal/service/nlp/retrieval_test.go
+++ b/internal/service/nlp/retrieval_test.go
@@ -252,11 +252,180 @@ func (e *captureSearchDocEngine) GetAggregation(_ []map[string]interface{}, _ st
 func (e *captureSearchDocEngine) GetHighlight(_ []map[string]interface{}, _ []string, _ string) map[string]string {
 	return nil
 }
+func (e *captureSearchDocEngine) KNNScores(context.Context, []map[string]interface{}, []float64, int) (map[string]interface{}, error) {
+	return map[string]interface{}{}, nil
+}
+func (e *captureSearchDocEngine) GetScores(map[string]interface{}) map[string]float64 {
+	return map[string]float64{}
+}
 
 type captureEmbeddingDriver struct{ modelModule.ModelDriver }
 
 func (d *captureEmbeddingDriver) Embed(_ context.Context, _ *string, _ modelModule.EmbedRequest, _ *modelModule.APIConfig, _ *modelModule.EmbeddingConfig, _ *common.ModelUsage) ([]modelModule.EmbeddingData, error) {
 	return []modelModule.EmbeddingData{{Embedding: []float64{0.1, 0.2}}}, nil
+}
+
+type retryCaptureEngine struct {
+	engine.DocEngine
+	totals   []int64
+	requests []*types.SearchRequest
+	mutate   bool
+}
+
+func (e *retryCaptureEngine) GetType() string { return string(engine.EngineElasticsearch) }
+func (e *retryCaptureEngine) Search(_ context.Context, req *types.SearchRequest) (*types.SearchResult, error) {
+	copyReq := *req
+	copyReq.MatchExprs = make([]interface{}, 0, len(req.MatchExprs))
+	for _, expr := range req.MatchExprs {
+		switch expr := expr.(type) {
+		case *types.MatchDenseExpr:
+			copyReq.MatchExprs = append(copyReq.MatchExprs, cloneDenseExpr(expr))
+		case *types.MatchTextExpr:
+			clone := *expr
+			copyReq.MatchExprs = append(copyReq.MatchExprs, &clone)
+		case *types.FusionExpr:
+			clone := *expr
+			clone.FusionParams = map[string]interface{}{}
+			for key, value := range expr.FusionParams {
+				clone.FusionParams[key] = value
+			}
+			copyReq.MatchExprs = append(copyReq.MatchExprs, &clone)
+		}
+	}
+	e.requests = append(e.requests, &copyReq)
+	if e.mutate {
+		for _, expr := range req.MatchExprs {
+			if dense, ok := expr.(*types.MatchDenseExpr); ok {
+				delete(dense.ExtraOptions, "num_candidates")
+				dense.ExtraOptions["backend"] = true
+			}
+		}
+	}
+	total := e.totals[0]
+	e.totals = e.totals[1:]
+	return &types.SearchResult{Total: total}, nil
+}
+func (e *retryCaptureEngine) GetChunkIDs([]map[string]interface{}) []string { return nil }
+func (e *retryCaptureEngine) GetFields([]map[string]interface{}, []string) map[string]map[string]interface{} {
+	return nil
+}
+func (e *retryCaptureEngine) GetAggregation([]map[string]interface{}, string) []map[string]interface{} {
+	return nil
+}
+func (e *retryCaptureEngine) GetHighlight([]map[string]interface{}, []string, string) map[string]string {
+	return nil
+}
+
+func TestSearchDenseRecoveryOnlyAfterEmptyLexicalAttempts(t *testing.T) {
+	if GetQueryBuilder() == nil {
+		globalQueryBuilder = NewQueryBuilder()
+	}
+
+	for _, test := range []struct {
+		name          string
+		totals        []int64
+		expectedCalls int
+		finalExprs    int
+	}{
+		{name: "hybrid hit", totals: []int64{1}, expectedCalls: 1, finalExprs: 3},
+		{name: "relaxed hit", totals: []int64{0, 1}, expectedCalls: 2, finalExprs: 3},
+		{name: "dense recovery", totals: []int64{0, 0, 1}, expectedCalls: 3, finalExprs: 1},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			docEngine := &retryCaptureEngine{totals: append([]int64(nil), test.totals...), mutate: true}
+			service := NewRetrievalService(docEngine, nil)
+			_, err := service.Search(t.Context(), &RetrievalSearchRequest{
+				Question: "risk", TenantIDs: []string{"tenant-1"}, KbIDs: []string{"kb-1"}, Page: 1, PageSize: 10,
+				KNNTopK: 7, KNNNumCandidates: 19, RankFeature: map[string]float64{"pagerank_fea": 2},
+				EmbeddingModel: &modelModule.EmbeddingModel{ModelDriver: &captureEmbeddingDriver{}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(docEngine.requests) != test.expectedCalls {
+				t.Fatalf("search calls = %d, want %d", len(docEngine.requests), test.expectedCalls)
+			}
+			last := docEngine.requests[len(docEngine.requests)-1]
+			if len(last.MatchExprs) != test.finalExprs {
+				t.Fatalf("final expressions = %d, want %d", len(last.MatchExprs), test.finalExprs)
+			}
+			for index, request := range docEngine.requests {
+				var dense *types.MatchDenseExpr
+				if len(request.MatchExprs) == 1 {
+					dense = request.MatchExprs[0].(*types.MatchDenseExpr)
+				} else {
+					dense = request.MatchExprs[1].(*types.MatchDenseExpr)
+				}
+				if dense.TopN != 7 || dense.ExtraOptions["num_candidates"] != 19 {
+					t.Fatalf("dense options lost on attempt %d: %#v", index+1, dense)
+				}
+				if _, contaminated := dense.ExtraOptions["backend"]; contaminated {
+					t.Fatalf("attempt %d inherited connector mutation", index+1)
+				}
+				wantSimilarity := 0.1
+				if index > 0 {
+					wantSimilarity = 0.17
+				}
+				if dense.ExtraOptions["similarity"] != wantSimilarity {
+					t.Fatalf("attempt %d similarity = %v, want %v", index+1, dense.ExtraOptions["similarity"], wantSimilarity)
+				}
+			}
+			if test.expectedCalls == 3 {
+				if last.Filter["kb_id"] == nil || last.Filter["available_int"] != 1 {
+					t.Fatalf("dense recovery lost scope filters: %#v", last.Filter)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchWithoutUsableTextDoesNotRetryDenseSearch(t *testing.T) {
+	docEngine := &retryCaptureEngine{totals: []int64{0}}
+	service := NewRetrievalService(docEngine, nil)
+	_, err := service.Search(t.Context(), &RetrievalSearchRequest{
+		Question: "!!!", TenantIDs: []string{"tenant-1"}, KbIDs: []string{"kb-1"}, Page: 1, PageSize: 10,
+		EmbeddingModel: &modelModule.EmbeddingModel{ModelDriver: &captureEmbeddingDriver{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docEngine.requests) != 1 || len(docEngine.requests[0].MatchExprs) != 1 {
+		t.Fatalf("dense-only query retried or retained lexical expressions: %#v", docEngine.requests)
+	}
+}
+
+func TestSearchDocIDKeepsFilterOnlyRetry(t *testing.T) {
+	docEngine := &retryCaptureEngine{totals: []int64{0, 1}}
+	service := NewRetrievalService(docEngine, nil)
+	_, err := service.Search(t.Context(), &RetrievalSearchRequest{
+		Question: "risk", TenantIDs: []string{"tenant-1"}, KbIDs: []string{"kb-1"}, DocIDs: []string{"doc-1"}, Page: 1, PageSize: 10,
+		EmbeddingModel: &modelModule.EmbeddingModel{ModelDriver: &captureEmbeddingDriver{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(docEngine.requests) != 2 || len(docEngine.requests[1].MatchExprs) != 0 {
+		t.Fatalf("doc-scoped retry changed: %#v", docEngine.requests)
+	}
+	if got := docEngine.requests[1].Filter["doc_id"]; fmt.Sprint(got) != "[doc-1]" {
+		t.Fatalf("doc_id filter = %v", got)
+	}
+}
+
+func TestCloneDenseExprDeepCopiesOptions(t *testing.T) {
+	source := &types.MatchDenseExpr{
+		EmbeddingData: []float64{0.1},
+		ExtraOptions: map[string]interface{}{
+			"sentinel": map[string]any{"future": []any{1}},
+		},
+	}
+	clone := cloneDenseExpr(source)
+	clone.EmbeddingData[0] = 0.9
+	clone.ExtraOptions["sentinel"].(map[string]any)["future"].([]any)[0] = 2
+
+	if source.EmbeddingData[0] != 0.1 || source.ExtraOptions["sentinel"].(map[string]any)["future"].([]any)[0] != 1 {
+		t.Fatalf("clone mutated source: %#v", source)
+	}
 }
 
 func TestSearchPassesVectorSimilarityWeightToFusionExpr(t *testing.T) {
@@ -284,7 +453,7 @@ func TestRetrievalPassesVectorSimilarityWeightToSearch(t *testing.T) {
 	top := 10
 	docEngine := &captureSearchDocEngine{
 		engineType: string(engine.EngineInfinity),
-		result:     &types.SearchResult{Chunks: []map[string]interface{}{}, Total: 0},
+		result:     &types.SearchResult{Chunks: []map[string]interface{}{}, Total: 1},
 	}
 	service := NewRetrievalService(docEngine, &dao.DocumentDAO{})
 	_, err := service.Retrieval(t.Context(), &RetrievalRequest{

--- a/rag/nlp/search.py
+++ b/rag/nlp/search.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import copy
 import json
 import logging
 import re
@@ -243,7 +244,8 @@ class Dealer:
                 total = self.dataStore.get_total(res)
                 logging.debug("Dealer.search TOTAL: {}".format(total))
             else:
-                matchDense = await self.get_vector(qst, emb_mdl, top_k=knn_top_k, num_candidates=knn_num_candidates, similarity=req.get("similarity", 0.1))
+                dense_template = await self.get_vector(qst, emb_mdl, top_k=knn_top_k, num_candidates=knn_num_candidates, similarity=req.get("similarity", 0.1))
+                matchDense = copy.deepcopy(dense_template)
                 q_vec = matchDense.embedding_data
                 # ES path no longer fetches chunk vectors here. The clean
                 # cosine score is recovered later via a second KNN-only call
@@ -261,12 +263,13 @@ class Dealer:
                         knn_top_k,
                         vector_similarity_weight,
                     )
-                    fusionExpr = build_fusion_expr(knn_top_k, vector_similarity_weight)
+                    fusion_template = build_fusion_expr(knn_top_k, vector_similarity_weight)
                 elif settings.DOC_ENGINE_GAUSSDB:
                     vector_weight = req.get("vector_similarity_weight", 0.3)
-                    fusionExpr = FusionExpr("weighted_sum", knn_top_k, {"weights": f"{1 - float(vector_weight)},{float(vector_weight)}"})
+                    fusion_template = FusionExpr("weighted_sum", knn_top_k, {"weights": f"{1 - float(vector_weight)},{float(vector_weight)}"})
                 else:
-                    fusionExpr = FusionExpr("weighted_sum", knn_top_k, {"weights": "0.001,1"})
+                    fusion_template = FusionExpr("weighted_sum", knn_top_k, {"weights": "0.001,1"})
+                fusionExpr = copy.deepcopy(fusion_template)
                 matchExprs = [matchText, matchDense, fusionExpr] if matchText else [matchDense]
 
                 res = await thread_pool_exec(self.dataStore.search, src, highlightFields, filters, matchExprs, orderBy, offset, limit, idx_names, kb_ids, rank_feature=rank_feature)
@@ -274,19 +277,20 @@ class Dealer:
                 logging.debug("Dealer.search TOTAL: {}".format(total))
 
                 # If result is empty, try again with lower min_match
-                if total == 0:
+                if total == 0 and matchText:
                     if filters.get("doc_id"):
                         res = await thread_pool_exec(self.dataStore.search, src, [], filters, [], orderBy, offset, limit, idx_names, kb_ids)
                         total = self.dataStore.get_total(res)
                     else:
                         matchText, _ = self.qryr.question(qst, min_match=(0.1 if min_match else 0))
-                        matchDense.extra_options["similarity"] = 0.17
+                        relaxed_dense = copy.deepcopy(dense_template)
+                        relaxed_dense.extra_options["similarity"] = 0.17
                         res = await thread_pool_exec(
                             self.dataStore.search,
                             src,
                             highlightFields,
                             filters,
-                            [matchText, matchDense, fusionExpr] if matchText else [matchDense],
+                            [matchText, relaxed_dense, copy.deepcopy(fusion_template)] if matchText else [relaxed_dense],
                             orderBy,
                             offset,
                             limit,
@@ -295,6 +299,24 @@ class Dealer:
                             rank_feature=rank_feature,
                         )
                         total = self.dataStore.get_total(res)
+                        if total == 0 and matchText:
+                            dense_fallback = copy.deepcopy(dense_template)
+                            dense_fallback.extra_options["similarity"] = 0.17
+                            logging.debug("Dealer.search dense-only recovery triggered after empty hybrid retries")
+                            res = await thread_pool_exec(
+                                self.dataStore.search,
+                                src,
+                                [],
+                                filters,
+                                [dense_fallback],
+                                orderBy,
+                                offset,
+                                limit,
+                                idx_names,
+                                kb_ids,
+                                rank_feature=rank_feature,
+                            )
+                            total = self.dataStore.get_total(res)
                     logging.debug("Dealer.search 2 TOTAL: {}".format(total))
 
             for k in keywords:

--- a/rag/utils/infinity_conn.py
+++ b/rag/utils/infinity_conn.py
@@ -247,8 +247,9 @@ class InfinityConnection(InfinityConnectionBase):
                     self.logger.debug(f"INFINITY search MatchTextExpr: {json.dumps(matchExpr.__dict__)}")
                 elif isinstance(matchExpr, MatchDenseExpr):
                     matchExpr.extra_options.pop("num_candidates", None)
-                    if filter_fulltext and "filter" not in matchExpr.extra_options:
-                        matchExpr.extra_options.update({"filter": filter_fulltext})
+                    dense_filter = filter_fulltext or filter_cond
+                    if dense_filter and "filter" not in matchExpr.extra_options:
+                        matchExpr.extra_options.update({"filter": dense_filter})
                     # dense_filter = _build_dense_filter(filter_cond, filter_fulltext, vector_similarity_weight)
                     # if dense_filter and "filter" not in matchExpr.extra_options:
                     #    matchExpr.extra_options.update({"filter": dense_filter})

--- a/test/unit_test/rag/nlp/test_gaussdb_retrieval.py
+++ b/test/unit_test/rag/nlp/test_gaussdb_retrieval.py
@@ -13,6 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+import copy
 import sys
 import types
 from unittest.mock import AsyncMock, Mock
@@ -206,6 +207,103 @@ class FakeGaussDBStore:
 class FakeQueryer:
     def question(self, text, min_match=0.3):
         return MatchTextExpr(["content_with_weight"], text, 1024), [text]
+
+
+class RetryStore(FakeGaussDBStore):
+    def __init__(self, totals, mutate=False):
+        self.totals = iter(totals)
+        self.calls = []
+        self.mutate = mutate
+
+    def search(self, *args, **kwargs):
+        self.calls.append(copy.deepcopy((args, kwargs)))
+        if self.mutate:
+            for expr in args[3]:
+                if isinstance(expr, MatchDenseExpr):
+                    expr.extra_options.pop("num_candidates", None)
+                    expr.extra_options["threshold"] = expr.extra_options.pop("similarity", None)
+                    expr.extra_options["backend"] = True
+                elif isinstance(expr, FusionExpr):
+                    expr.fusion_params["normalize"] = "backend"
+        return type("SearchResult", (), {"total": next(self.totals), "chunks": []})()
+
+
+async def run_retry_search(dealer_cls, totals, queryer=None, mutate=False, doc_ids=None):
+    dealer = make_dealer(dealer_cls)
+    dealer.qryr = queryer or FakeQueryer()
+    dealer.dataStore = RetryStore(totals, mutate=mutate)
+
+    async def fake_get_vector(_text, _emb_mdl, top_k=10, num_candidates=20, similarity=0.1):
+        return MatchDenseExpr(
+            "q_4_vec",
+            [0.1, 0.2, 0.3, 0.4],
+            "float",
+            "cosine",
+            top_k,
+            {"similarity": similarity, "num_candidates": num_candidates, "sentinel": {"future": [1]}},
+        )
+
+    dealer.get_vector = fake_get_vector
+    req = {"question": "risk", "page": 1, "size": 5, "knn_top_k": 7, "knn_num_candidates": 19}
+    if doc_ids:
+        req["doc_ids"] = doc_ids
+    await dealer.search(req, "ragflow_tenant", ["kb1"], emb_mdl=object(), highlight=True)
+    return dealer.dataStore.calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("totals", "expected_calls", "final_expr_count"),
+    [([1], 1, 3), ([0, 1], 2, 3), ([0, 0, 1], 3, 1)],
+)
+async def test_dense_recovery_runs_only_after_zero_lexical_results(dealer_cls, totals, expected_calls, final_expr_count):
+    calls = await run_retry_search(dealer_cls, totals)
+
+    assert len(calls) == expected_calls
+    assert len(calls[-1][0][3]) == final_expr_count
+    if expected_calls == 3:
+        final_args, _ = calls[-1]
+        dense = final_args[3][0]
+        assert isinstance(dense, MatchDenseExpr)
+        assert final_args[1] == []
+        assert dense.extra_options == {
+            "similarity": 0.17,
+            "num_candidates": 19,
+            "sentinel": {"future": [1]},
+        }
+
+
+@pytest.mark.asyncio
+async def test_dense_retries_are_isolated_from_connector_mutation(dealer_cls):
+    calls = await run_retry_search(dealer_cls, [0, 0, 1], mutate=True)
+
+    for index, (args, _) in enumerate(calls):
+        dense = next(expr for expr in args[3] if isinstance(expr, MatchDenseExpr))
+        assert dense.extra_options["num_candidates"] == 19
+        assert dense.extra_options["sentinel"] == {"future": [1]}
+        assert dense.extra_options["similarity"] == (0.1 if index == 0 else 0.17)
+        assert "threshold" not in dense.extra_options
+        assert "backend" not in dense.extra_options
+
+
+@pytest.mark.asyncio
+async def test_no_usable_text_stays_single_dense_search(dealer_cls):
+    queryer = types.SimpleNamespace(question=lambda *_args, **_kwargs: (None, []))
+    calls = await run_retry_search(dealer_cls, [0], queryer=queryer)
+
+    assert len(calls) == 1
+    assert len(calls[0][0][3]) == 1
+    assert isinstance(calls[0][0][3][0], MatchDenseExpr)
+
+
+@pytest.mark.asyncio
+async def test_doc_id_zero_result_keeps_filter_only_retry(dealer_cls):
+    calls = await run_retry_search(dealer_cls, [0, 1], doc_ids=["doc-1"])
+
+    assert len(calls) == 2
+    assert calls[1][0][1] == []
+    assert calls[1][0][2]["doc_id"] == ["doc-1"]
+    assert calls[1][0][3] == []
 
 
 def retrieval_chunk(score, doc_id, doc_name, content="risk contract"):

--- a/test/unit_test/rag/utils/test_infinity_conn_helpers.py
+++ b/test/unit_test/rag/utils/test_infinity_conn_helpers.py
@@ -31,7 +31,9 @@ pool and exercise the routing logic. Run with::
 import logging
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
+from common.doc_store.doc_store_base import MatchDenseExpr, OrderByExpr
 
 pytestmark = pytest.mark.p2
 
@@ -53,6 +55,34 @@ def _resolve_infinity_class():
 
 
 _Inf = _resolve_infinity_class()
+
+
+def test_dense_search_keeps_scope_filter_without_fulltext():
+    conn = _Inf.__new__(_Inf)
+    conn.dbName = "default_db"
+    conn.logger = logging.getLogger("test.infinity_dense_scope")
+    conn.equivalent_condition_to_str = lambda *_args: "doc_id IN ('doc-1') AND available_int=1"
+
+    builder = MagicMock()
+    for method in ("match_dense", "offset", "limit", "option"):
+        getattr(builder, method).return_value = builder
+    builder.to_df.return_value = (
+        pd.DataFrame([{"id": "chunk-1", "SIMILARITY": 0.9, "pagerank_fea": 0.0}]),
+        {"total_hits_count": 1},
+    )
+    table = MagicMock()
+    table.output.return_value = builder
+    db = MagicMock()
+    db.get_table.return_value = table
+    inf_conn = MagicMock()
+    inf_conn.get_database.return_value = db
+    conn.connPool = MagicMock()
+    conn.connPool.get_conn.return_value = inf_conn
+
+    dense = MatchDenseExpr("q_2_vec", [0.1, 0.2], "float", "cosine", 7, {"similarity": 0.17, "num_candidates": 19})
+    conn.search(["id"], [], {"doc_id": ["doc-1"], "available_int": 1}, [dense], OrderByExpr(), 0, 5, "ragflow_tenant", ["kb-1"])
+
+    assert builder.match_dense.call_args.args[-1]["filter"] == "doc_id IN ('doc-1') AND available_int=1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Dense search runs when both hybrid attempts return nothing. Existing results and search filters remain unchanged.