### PR TITLE
fix(tree): preserve document boundaries and complete graph projection

### DIFF
--- a/internal/ingestion/component/knowledge_compiler/tree/graph.go
+++ b/internal/ingestion/component/knowledge_compiler/tree/graph.go
@@ -241,6 +241,13 @@ func buildTreeGraph(ctx context.Context, deps common.Deps, docID string, product
 	}
 	root = collapseUnary(root)
 	entities, relations := raptorTreeToGraph(root)
+	var rootVector []float32
+	for i := range products {
+		if kind, _ := products[i].Meta["kind"].(string); kind == "root" {
+			rootVector = products[i].Vector
+			break
+		}
+	}
 
 	var out []common.Product
 	var descs []string
@@ -303,21 +310,13 @@ func buildTreeGraph(ctx context.Context, deps common.Deps, docID string, product
 	// Compact graph blob discovery row (knowledge_graph_kwd="graph").
 	graph := map[string]any{"entities": entities, "relations": relations}
 	graphContent := payloadJSON(graph)
-	graphVecs, err := deps.Embed.Encode(ctx, []string{graphContent})
-	if err != nil {
-		return nil, err
-	}
-	var gv []float32
-	if len(graphVecs) > 0 {
-		gv = graphVecs[0]
-	}
 	out = append(out, common.Product{
 		ID:       common.StableRowID(docID, "tree", "structure_graph"),
 		DocID:    docID,
 		TenantID: deps.TenantID,
 		Variant:  common.VariantTree,
 		Content:  graphContent,
-		Vector:   gv,
+		Vector:   rootVector,
 		Meta: map[string]any{
 			"kind":        "graph",
 			"compile_kwd": "tree",

--- a/internal/ingestion/component/knowledge_compiler/tree/graph.go
+++ b/internal/ingestion/component/knowledge_compiler/tree/graph.go
@@ -127,6 +127,7 @@ func payloadJSON(payload map[string]any) string {
 type graphNode struct {
 	title          string
 	description    string
+	vector         []float32
 	sourceChunkIDs []string
 	children       []*graphNode
 }
@@ -239,14 +240,19 @@ func buildTreeGraph(ctx context.Context, deps common.Deps, docID string, product
 		// No root summary survived; there is no tree to project.
 		return nil, nil
 	}
+	rootVector := root.vector
+	rootSummary := firstNonEmpty(root.description, root.title)
 	root = collapseUnary(root)
 	entities, relations := raptorTreeToGraph(root)
-	var rootVector []float32
-	for i := range products {
-		if kind, _ := products[i].Meta["kind"].(string); kind == "root" {
-			rootVector = products[i].Vector
-			break
+	if len(rootVector) == 0 {
+		vectors, err := deps.Embed.Encode(ctx, []string{rootSummary})
+		if err != nil {
+			return nil, fmt.Errorf("tree: embed graph discovery fallback: %w", err)
 		}
+		if len(vectors) == 0 || len(vectors[0]) == 0 {
+			return nil, fmt.Errorf("tree: embed graph discovery fallback returned no vector")
+		}
+		rootVector = vectors[0]
 	}
 
 	var out []common.Product
@@ -310,6 +316,8 @@ func buildTreeGraph(ctx context.Context, deps common.Deps, docID string, product
 	// Compact graph blob discovery row (knowledge_graph_kwd="graph").
 	graph := map[string]any{"entities": entities, "relations": relations}
 	graphContent := payloadJSON(graph)
+	// Reuse the selected root summary vector as a bounded semantic proxy: the
+	// full graph blob can exceed embedding-model input limits.
 	out = append(out, common.Product{
 		ID:       common.StableRowID(docID, "tree", "structure_graph"),
 		DocID:    docID,
@@ -336,6 +344,7 @@ func reconstructTree(products []common.Product) *graphNode {
 		byID[p.ID] = &graphNode{
 			title:          title,
 			description:    p.Content,
+			vector:         p.Vector,
 			sourceChunkIDs: stringMetaSlice(p.Meta["source_chunk_ids"]),
 		}
 	}

--- a/internal/ingestion/component/knowledge_compiler/tree/graph_test.go
+++ b/internal/ingestion/component/knowledge_compiler/tree/graph_test.go
@@ -1,11 +1,29 @@
 package tree
 
 import (
+	"context"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"ragflow/internal/ingestion/component/knowledge_compiler/common"
 )
+
+type sizeLimitedEmbedder struct{}
+
+func (sizeLimitedEmbedder) Dimensions() int { return 2 }
+
+func (sizeLimitedEmbedder) Encode(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		if len(text) > 500 {
+			return nil, fmt.Errorf("input too large: %d", len(text))
+		}
+		out[i] = []float32{1, 0}
+	}
+	return out, nil
+}
 
 // TestRaptorTreeToGraph_CollapsesUnaryAndProjects verifies the tree→graph
 // projection matches Python raptor_tree_to_graph: unary chains are collapsed
@@ -103,5 +121,41 @@ func TestReconstructTree_FromFlatProducts(t *testing.T) {
 	}
 	if len(root.children[0].children) != 1 || root.children[0].children[0].title != "N2" {
 		t.Fatalf("N1 children = %+v, want [N2]", root.children[0].children)
+	}
+}
+
+func TestBuildTreeGraph_LongDocumentDoesNotEmbedGraphBlob(t *testing.T) {
+	products := []common.Product{{
+		ID: "root", DocID: "doc", TenantID: "tenant", Content: "collection summary",
+		Vector: []float32{0, 1}, Meta: map[string]any{"kind": "root", "title": "Document"},
+	}}
+	for i := range 40 {
+		products = append(products, common.Product{
+			ID:       fmt.Sprintf("node-%d", i),
+			DocID:    "doc",
+			TenantID: "tenant",
+			ParentID: "root",
+			Content:  fmt.Sprintf("section %d", i),
+			Meta: map[string]any{
+				"kind":             "summary",
+				"title":            fmt.Sprintf("Section %d", i),
+				"source_chunk_ids": []string{fmt.Sprintf("chunk-%d", i)},
+			},
+		})
+	}
+
+	got, err := buildTreeGraph(t.Context(), common.Deps{TenantID: "tenant", Embed: sizeLimitedEmbedder{}}, "doc", products)
+	if err != nil {
+		t.Fatalf("buildTreeGraph: %v", err)
+	}
+	if len(got) != 82 { // 41 entities + 40 relations + 1 compact graph row
+		t.Fatalf("got %d products, want 82", len(got))
+	}
+	graph := got[len(got)-1]
+	if graph.Meta["kind"] != "graph" || !strings.Contains(graph.Content, "chunk-39") {
+		t.Fatalf("compact graph lost late-document coverage: kind=%v content=%q", graph.Meta["kind"], graph.Content)
+	}
+	if !reflect.DeepEqual(graph.Vector, []float32{0, 1}) {
+		t.Fatalf("compact discovery row should reuse the root vector, got %v", graph.Vector)
 	}
 }

--- a/internal/ingestion/component/knowledge_compiler/tree/graph_test.go
+++ b/internal/ingestion/component/knowledge_compiler/tree/graph_test.go
@@ -124,6 +124,32 @@ func TestReconstructTree_FromFlatProducts(t *testing.T) {
 	}
 }
 
+func TestReconstructTree_LastRootWinsWithItsVector(t *testing.T) {
+	products := []common.Product{
+		{ID: "first", Vector: []float32{1, 0}, Meta: map[string]any{"kind": "root", "title": "first"}},
+		{ID: "last", Vector: []float32{0, 1}, Meta: map[string]any{"kind": "root", "title": "last"}},
+	}
+	root := reconstructTree(products)
+	if root == nil || root.title != "last" || !reflect.DeepEqual(root.vector, []float32{0, 1}) {
+		t.Fatalf("reconstructed root = %+v, want last root and its vector", root)
+	}
+}
+
+func TestBuildTreeGraph_EmbedsRootSummaryWhenVectorMissing(t *testing.T) {
+	products := []common.Product{{
+		ID: "root", DocID: "doc", TenantID: "tenant", Content: "document summary",
+		Meta: map[string]any{"kind": "root", "title": "Document"},
+	}}
+	got, err := buildTreeGraph(t.Context(), common.Deps{TenantID: "tenant", Embed: sizeLimitedEmbedder{}}, "doc", products)
+	if err != nil {
+		t.Fatalf("buildTreeGraph: %v", err)
+	}
+	graph := got[len(got)-1]
+	if !reflect.DeepEqual(graph.Vector, []float32{1, 0}) {
+		t.Fatalf("graph fallback vector = %v, want embedded root summary", graph.Vector)
+	}
+}
+
 func TestBuildTreeGraph_LongDocumentDoesNotEmbedGraphBlob(t *testing.T) {
 	products := []common.Product{{
 		ID: "root", DocID: "doc", TenantID: "tenant", Content: "collection summary",

--- a/internal/ingestion/component/tokenizer.go
+++ b/internal/ingestion/component/tokenizer.go
@@ -431,6 +431,10 @@ func (c *TokenizerComponent) embedChunks(ctx context.Context, tenantID, kbID, na
 	// Set-side key matches the Get-side key for freshly embedded content.
 	truncs := make([]string, 0, len(chunks))
 	for i, ck := range chunks {
+		compileKWD, _ := ck.GetExtraString("compile_kwd")
+		if compileKWD != "" && hasEmbeddingVector(ck) {
+			continue
+		}
 		raw := concatFields(ck, c.param.Fields)
 		txt := htmlTableRE.ReplaceAllString(raw, " ")
 		txt = strings.TrimSpace(txt)

--- a/internal/ingestion/component/tokenizer.go
+++ b/internal/ingestion/component/tokenizer.go
@@ -432,7 +432,11 @@ func (c *TokenizerComponent) embedChunks(ctx context.Context, tenantID, kbID, na
 	truncs := make([]string, 0, len(chunks))
 	for i, ck := range chunks {
 		compileKWD, _ := ck.GetExtraString("compile_kwd")
-		if compileKWD != "" && hasEmbeddingVector(ck) {
+		kind, _ := ck.GetExtraString("kc_kind")
+		// The tree graph blob reuses its root-summary vector because embedding the
+		// complete graph may exceed the model limit. Other compiled rows are
+		// re-embedded normally so model changes cannot leave stale vectors.
+		if compileKWD == "tree" && kind == "graph" && hasEmbeddingVector(ck) {
 			continue
 		}
 		raw := concatFields(ck, c.param.Fields)

--- a/internal/ingestion/component/tokenizer_unit_test.go
+++ b/internal/ingestion/component/tokenizer_unit_test.go
@@ -240,6 +240,38 @@ func TestTokenizerComponent_Invoke_EmbeddingOnly(t *testing.T) {
 	}
 }
 
+func TestTokenizerComponent_PreservesPrecomputedEmbedding(t *testing.T) {
+	stub := newStubEmbedder(4)
+	component, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(context.Context, string, string) (Embedder, string, error) {
+		return stub, "embd-test", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := component.(*TokenizerComponent)
+	out, err := c.Invoke(t.Context(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"output_format": "chunks",
+		"chunks": []map[string]any{{
+			"text":        strings.Repeat("large compiled graph ", 1000),
+			"compile_kwd": "tree",
+			"q_4_vec":     []float64{1, 2, 3, 4},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := stub.calls.Load(); got != 0 {
+		t.Fatalf("embedder called %d times for a precomputed vector, want 0", got)
+	}
+	chunks := out["chunks"].([]map[string]any)
+	if !reflect.DeepEqual(chunks[0]["q_4_vec"], []float64{1, 2, 3, 4}) {
+		t.Fatalf("precomputed vector changed: %v", chunks[0]["q_4_vec"])
+	}
+}
+
 // TestTokenizerComponent_Embedding_ZeroChunksStillEmitsConsumptionZero uses an
 // empty chunk list, so tokenizeChunks is a no-op and the C++ pool is not needed.
 func TestTokenizerComponent_Embedding_ZeroChunksStillEmitsConsumptionZero(t *testing.T) {

--- a/internal/ingestion/component/tokenizer_unit_test.go
+++ b/internal/ingestion/component/tokenizer_unit_test.go
@@ -257,6 +257,7 @@ func TestTokenizerComponent_PreservesPrecomputedEmbedding(t *testing.T) {
 		"chunks": []map[string]any{{
 			"text":        strings.Repeat("large compiled graph ", 1000),
 			"compile_kwd": "tree",
+			"kc_kind":     "graph",
 			"q_4_vec":     []float64{1, 2, 3, 4},
 		}},
 	})
@@ -269,6 +270,35 @@ func TestTokenizerComponent_PreservesPrecomputedEmbedding(t *testing.T) {
 	chunks := out["chunks"].([]map[string]any)
 	if !reflect.DeepEqual(chunks[0]["q_4_vec"], []float64{1, 2, 3, 4}) {
 		t.Fatalf("precomputed vector changed: %v", chunks[0]["q_4_vec"])
+	}
+}
+
+func TestTokenizerComponent_ReembedsOtherCompiledProducts(t *testing.T) {
+	stub := newStubEmbedder(4)
+	component, err := NewTokenizerComponentWithResolver(map[string]any{
+		"search_method": []any{"embedding"},
+	}, func(context.Context, string, string) (Embedder, string, error) {
+		return stub, "embd-test", nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := component.(*TokenizerComponent)
+	_, err = c.Invoke(t.Context(), nil, map[string]any{
+		"kb_id":         "kb-1",
+		"output_format": "chunks",
+		"chunks": []map[string]any{{
+			"text":        "compiled entity",
+			"compile_kwd": "knowledge_graph",
+			"kc_kind":     "entity",
+			"q_4_vec":     []float64{1, 2, 3, 4},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Invoke: %v", err)
+	}
+	if got := stub.calls.Load(); got != 1 {
+		t.Fatalf("embedder called %d times, want 1", got)
 	}
 }
 

--- a/internal/ingestion/knowledge_compile/consumer.go
+++ b/internal/ingestion/knowledge_compile/consumer.go
@@ -1435,7 +1435,7 @@ func navInputFromProducts(kb string, products []kccommon.Product) []nav.UpsertDo
 			}
 			a := byDoc[p.DocID]
 			if a == nil {
-				byDoc[p.DocID] = &acc{in: nav.UpsertDocInput{TenantID: p.TenantID, KbID: kb, DocID: p.DocID}}
+				byDoc[p.DocID] = &acc{in: nav.UpsertDocInput{TenantID: p.TenantID, KbID: kb, DocID: p.DocID, PreserveDocumentBoundary: true}}
 				a = byDoc[p.DocID]
 			}
 			a.in.Summary = p.Content

--- a/internal/ingestion/knowledge_compile/consumer.go
+++ b/internal/ingestion/knowledge_compile/consumer.go
@@ -1435,11 +1435,12 @@ func navInputFromProducts(kb string, products []kccommon.Product) []nav.UpsertDo
 			}
 			a := byDoc[p.DocID]
 			if a == nil {
-				byDoc[p.DocID] = &acc{in: nav.UpsertDocInput{TenantID: p.TenantID, KbID: kb, DocID: p.DocID, PreserveDocumentBoundary: true}}
+				byDoc[p.DocID] = &acc{in: nav.UpsertDocInput{TenantID: p.TenantID, KbID: kb, DocID: p.DocID}}
 				a = byDoc[p.DocID]
 			}
 			a.in.Summary = p.Content
 			a.in.Embedd = p.Vector
+			a.in.PreserveDocumentBoundary = true
 		case kccommon.VariantStructure:
 			if kind, _ := p.Meta["kind"].(string); kind != "graph" {
 				continue

--- a/internal/ingestion/knowledge_compile/nav_dispatch_test.go
+++ b/internal/ingestion/knowledge_compile/nav_dispatch_test.go
@@ -65,6 +65,21 @@ func TestNavInputFromProducts_TreeAndStructure(t *testing.T) {
 	}
 }
 
+func TestNavInputFromProducts_TreeSetsBoundaryAfterStructure(t *testing.T) {
+	products := []kccommon.Product{
+		{DocID: "d1", TenantID: "t1", Variant: kccommon.VariantStructure,
+			Content: `{"entities":[{"name":"Engine","description":"structure"}]}`,
+			Meta:    map[string]any{"kind": "graph"}},
+		{DocID: "d1", TenantID: "t1", Variant: kccommon.VariantTree,
+			Content: "tree summary", Vector: []float32{0.1, 0.2},
+			Meta: map[string]any{"kind": "root"}},
+	}
+	got := navInputFromProducts("kb1", products)
+	if len(got) != 1 || !got[0].PreserveDocumentBoundary {
+		t.Fatalf("tree product must preserve boundary regardless of product order: %+v", got)
+	}
+}
+
 // TestNavInputFromProducts_WikiExcluded covers the dispatch boundary: wiki
 // products never become nav inputs (they go to the page-specific wiki merge).
 func TestNavInputFromProducts_WikiExcluded(t *testing.T) {

--- a/internal/ingestion/knowledge_compile/nav_dispatch_test.go
+++ b/internal/ingestion/knowledge_compile/nav_dispatch_test.go
@@ -45,6 +45,9 @@ func TestNavInputFromProducts_TreeAndStructure(t *testing.T) {
 	if !reflect.DeepEqual(treeIn.Embedd, []float32{0.1, 0.2}) {
 		t.Errorf("tree embedd should be the root vector, got %v", treeIn.Embedd)
 	}
+	if !treeIn.PreserveDocumentBoundary {
+		t.Error("tree nav input must preserve the document boundary")
+	}
 	structIn, ok := byDoc["d2"]
 	if !ok {
 		t.Fatal("missing structure nav input for d2")
@@ -56,6 +59,9 @@ func TestNavInputFromProducts_TreeAndStructure(t *testing.T) {
 	// NavService embeds the folded summary text.
 	if len(structIn.Embedd) != 0 {
 		t.Errorf("structure embedd should be empty (NavService re-embeds), got %v", structIn.Embedd)
+	}
+	if structIn.PreserveDocumentBoundary {
+		t.Error("structure nav input should retain semantic clustering")
 	}
 }
 

--- a/internal/service/nav/nav.go
+++ b/internal/service/nav/nav.go
@@ -50,11 +50,12 @@ type NavHit struct {
 
 // UpsertDocInput carries the per-document summary to place into the nav tree.
 type UpsertDocInput struct {
-	TenantID string
-	KbID     string
-	DocID    string
-	Summary  string    // document summary text (tree product or page_index summary)
-	Embedd   []float32 // optional precomputed embedding
+	TenantID                 string
+	KbID                     string
+	DocID                    string
+	Summary                  string    // document summary text (tree product or page_index summary)
+	Embedd                   []float32 // optional precomputed embedding
+	PreserveDocumentBoundary bool      // keep independent document trees as root branches
 }
 
 // NavMergeLLM summarizes or merges nav text via an LLM. It mirrors the Python

--- a/internal/service/nlp/datasetnav.go
+++ b/internal/service/nlp/datasetnav.go
@@ -369,9 +369,14 @@ func (s *NavService) UpsertDoc(ctx context.Context, in nav.UpsertDocInput) error
 		}
 	}
 
-	bestName, sim, bestDepth, err := s.findBestCluster(ctx, in.TenantID, in.KbID, vec)
-	if err != nil {
-		return err
+	var bestName string
+	var sim float64
+	var bestDepth int
+	if !in.PreserveDocumentBoundary {
+		bestName, sim, bestDepth, err = s.findBestCluster(ctx, in.TenantID, in.KbID, vec)
+		if err != nil {
+			return err
+		}
 	}
 	idx := s.navIndexName(in.TenantID)
 

--- a/internal/service/nlp/datasetnav_test.go
+++ b/internal/service/nlp/datasetnav_test.go
@@ -476,6 +476,33 @@ func TestNavService_Acceptance4_ListChildren(t *testing.T) {
 	}
 }
 
+func TestNavService_UpsertDoc_PreservesTreeDocumentBoundaries(t *testing.T) {
+	for _, docs := range [][]string{{"A"}, {"A", "B", "C"}, {"C", "B", "A"}} {
+		eng := newMemNavEngine()
+		ns := newTestNav(eng)
+		for _, doc := range docs {
+			in := navUpsertInput("t1", "kb1", doc, "shared summary "+doc)
+			in.Embedd = []float32{1, 1}
+			in.PreserveDocumentBoundary = true
+			if err := ns.UpsertDoc(t.Context(), in); err != nil {
+				t.Fatalf("UpsertDoc(%s): %v", doc, err)
+			}
+		}
+		clusters, total, err := ns.ListClusters(t.Context(), "t1", "kb1", 0, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != int64(len(docs)) || len(clusters) != len(docs) {
+			t.Fatalf("order %v: got %d root branches, want %d", docs, total, len(docs))
+		}
+		for _, cluster := range clusters {
+			if cluster.DocCount != 1 {
+				t.Errorf("order %v: root %q contains %d documents, want 1", docs, cluster.Name, cluster.DocCount)
+			}
+		}
+	}
+}
+
 // TestNavService_NavDocDepth asserts a nav_doc merged under a root cluster
 // (depth 0) gets depth_int = parentDepth+1 = 1, not a hard-coded value.
 func TestNavService_NavDocDepth(t *testing.T) {


### PR DESCRIPTION
Tree documents now remain separate top-level branches. Large Tree graphs no longer fail during embedding.