### PR TITLE
fix(agent): preserve Boolean values in Variable Assigner

### DIFF
--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -109,6 +109,10 @@ class VariableAssigner(ComponentBase, ABC):
         elif isinstance(variable, str):
             return self._canvas.get_value_with_variable(parameter)
         elif isinstance(variable, bool):
+            if parameter == "yes":
+                return True
+            elif parameter == "no":
+                return False
             return parameter
         elif isinstance(variable, int):
             return parameter

--- a/agent/component/variable_assigner.py
+++ b/agent/component/variable_assigner.py
@@ -109,10 +109,13 @@ class VariableAssigner(ComponentBase, ABC):
         elif isinstance(variable, str):
             return self._canvas.get_value_with_variable(parameter)
         elif isinstance(variable, bool):
-            if parameter == "yes":
-                return True
-            elif parameter == "no":
-                return False
+            # Accept yes/true and no/false spellings case-insensitively.
+            if isinstance(parameter, str):
+                normalized = parameter.lower()
+                if normalized in {"yes", "true"}:
+                    return True
+                elif normalized in {"no", "false"}:
+                    return False
             return parameter
         elif isinstance(variable, int):
             return parameter

--- a/internal/agent/component/variable_assigner.go
+++ b/internal/agent/component/variable_assigner.go
@@ -284,6 +284,17 @@ func operate(state *runtime.CanvasState, oldVal any, op string, param any) (any,
 				}
 			}
 			return param, ""
+		case bool:
+			// Accept yes/true and no/false spellings case-insensitively.
+			if s, ok := param.(string); ok {
+				switch strings.ToLower(s) {
+				case "yes", "true":
+					return true, ""
+				case "no", "false":
+					return false, ""
+				}
+			}
+			return param, ""
 		default:
 			return param, ""
 		}

--- a/internal/agent/component/variable_assigner_test.go
+++ b/internal/agent/component/variable_assigner_test.go
@@ -82,6 +82,56 @@ func TestVariableAssigner_Overwrite(t *testing.T) {
 	}
 }
 
+// TestVariableAssigner_SetBoolean: boolean spellings are normalized
+// case-insensitively, while native booleans are passed through unchanged.
+func TestVariableAssigner_SetBoolean(t *testing.T) {
+	tests := []struct {
+		name      string
+		parameter any
+		want      bool
+	}{
+		{name: "native true", parameter: true, want: true},
+		{name: "native false", parameter: false, want: false},
+		{name: "legacy yes", parameter: "yes", want: true},
+		{name: "legacy no", parameter: "no", want: false},
+		{name: "uppercase yes", parameter: "YES", want: true},
+		{name: "mixed-case no", parameter: "No", want: false},
+		{name: "true spelling", parameter: "true", want: true},
+		{name: "uppercase false spelling", parameter: "FALSE", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := canvas.NewCanvasState("run-set-boolean", "task-set-boolean")
+			state.Outputs["cpn_0"] = map[string]any{"flag": false}
+			ctx := canvas.WithState(t.Context(), state)
+
+			vars := []map[string]any{
+				{
+					"variable":  "cpn_0@flag",
+					"operator":  "set",
+					"parameter": tt.parameter,
+				},
+			}
+			c, err := NewVariableAssignerComponent(map[string]any{"variables": vars})
+			if err != nil {
+				t.Fatalf("NewVariableAssignerComponent: %v", err)
+			}
+			if _, err = c.Invoke(ctx, nil, nil); err != nil {
+				t.Fatalf("Invoke: %v", err)
+			}
+
+			got, ok := state.Outputs["cpn_0"]["flag"].(bool)
+			if !ok {
+				t.Fatalf("flag has type %T, want bool", state.Outputs["cpn_0"]["flag"])
+			}
+			if got != tt.want {
+				t.Errorf("flag: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestVariableAssigner_DivideByZero: assert "ERROR:DIVIDE_BY_ZERO"
 // returned, state unchanged.
 func TestVariableAssigner_DivideByZero(t *testing.T) {

--- a/test/unit_test/agent/component/test_variable_assigner.py
+++ b/test/unit_test/agent/component/test_variable_assigner.py
@@ -18,6 +18,7 @@ from agent.component.variable_assigner import VariableAssigner
     ],
 )
 def test_set_boolean_normalizes_boolean_spellings(parameter, expected):
+    # Boolean normalization does not access instance state, so initialization is unnecessary.
     component = VariableAssigner.__new__(VariableAssigner)
 
     result = component._set(False, parameter)

--- a/test/unit_test/agent/component/test_variable_assigner.py
+++ b/test/unit_test/agent/component/test_variable_assigner.py
@@ -11,9 +11,13 @@ from agent.component.variable_assigner import VariableAssigner
         (False, False),
         ("yes", True),
         ("no", False),
+        ("YES", True),
+        ("No", False),
+        ("true", True),
+        ("FALSE", False),
     ],
 )
-def test_set_boolean_preserves_booleans_and_migrates_legacy_values(parameter, expected):
+def test_set_boolean_normalizes_boolean_spellings(parameter, expected):
     component = VariableAssigner.__new__(VariableAssigner)
 
     result = component._set(False, parameter)

--- a/test/unit_test/agent/component/test_variable_assigner.py
+++ b/test/unit_test/agent/component/test_variable_assigner.py
@@ -1,0 +1,22 @@
+import pytest
+
+from agent.component.variable_assigner import VariableAssigner
+
+
+@pytest.mark.p1
+@pytest.mark.parametrize(
+    ("parameter", "expected"),
+    [
+        (True, True),
+        (False, False),
+        ("yes", True),
+        ("no", False),
+    ],
+)
+def test_set_boolean_preserves_booleans_and_migrates_legacy_values(parameter, expected):
+    component = VariableAssigner.__new__(VariableAssigner)
+
+    result = component._set(False, parameter)
+
+    assert result is expected
+    assert type(result) is bool


### PR DESCRIPTION
### Summary

Fix the Variable Assigner Boolean `Set` operation converting Boolean values from the Agent form into strings at runtime.

The existing frontend Boolean control submits `"yes"` and `"no"`. When the target variable is Boolean, the Python backend currently returns those values unchanged, so a Boolean variable can become a string after assignment. This change normalizes those values at the execution boundary while keeping the existing frontend behavior and saved DSL format unchanged.

### Problem

The normal Agent path is:

`Agent canvas` -> `Variable Assigner` -> Boolean variable -> `Set` -> `Yes/No` -> downstream Agent component.

The Boolean editor in `web/src/pages/agent/form/variable-assigner-form/dynamic-variables.tsx` uses a `RadioGroup` whose values are the strings `"yes"` and `"no"`. The backend then handles a Boolean target in `agent/component/variable_assigner.py` as follows:

```python
elif isinstance(variable, bool):
    return parameter
```

Therefore, assigning `No` to a Boolean variable can store `"no"` with type `str` instead of `False` with type `bool`. A later Switch or Loop condition can then compare the wrong runtime type and route the workflow incorrectly.

### Change

- Convert `"yes"` to `True` and `"no"` to `False` when Variable Assigner assigns a Boolean variable.
- Add a parametrized regression test covering native Boolean values and the existing `"yes"`/`"no"` form values.
