### PR TITLE
fix(figure_parser): accept lang as named parameter on VisionFigureParser (#17280)

### DIFF
--- a/deepdoc/parser/figure_parser.py
+++ b/deepdoc/parser/figure_parser.py
@@ -235,9 +235,16 @@ shared_executor = ThreadPoolExecutor(max_workers=10)
 
 
 class VisionFigureParser:
-    def __init__(self, vision_model, figures_data, *args, **kwargs):
+    def __init__(self, vision_model, figures_data, *args, lang="English", **kwargs):
         self.vision_model = vision_model
-        self.language = kwargs.get("lang") or "English"
+        # Accept `lang` as a named parameter instead of pulling it out
+        # of `**kwargs`: the wrappers above pass `lang=lang` explicitly
+        # and previously relied on kwargs lookup, which works but is
+        # easy to miss when adding new call sites. A named parameter
+        # is clearer at the contract level. Regression for #17280.
+        # `**kwargs.get("lang")` is kept as a fallback so older callers
+        # that don't pass `lang` keep working.
+        self.language = _normalize_vision_language(lang) or kwargs.get("lang") or "English"
         self.figure_contexts = kwargs.get("figure_contexts") or []
         self.context_size = max(0, int(kwargs.get("context_size", 0) or 0))
         self._extract_figures_info(figures_data)


### PR DESCRIPTION
"Fixes #17280.\n\nRe-opened as a clean PR per JinHai-CN's request \u2014 the previous #18392 had 929k insertions and 111k deletions because it carried the full main-sync history forward from when the branch was first cut. This version is the same 7-line fix (now +9 / -2) rebased onto current `upstream/main`, with no unrelated changes.\n\n## Problem\n\n`VisionFigureParser.__init__` previously took `*args, **kwargs` and read the dataset language via `kwargs.get(\"lang\")`. The three wrappers above pass `lang=lang` as an explicit keyword argument, so `kwargs.get(\"lang\")` did return the value \u2014 but the contract was implicit and easy to miss when adding new call sites. Any caller that forgets `lang=` and only forwards `**kwargs` would silently default to English.\n\n## Fix\n\n`deepdoc/parser/figure_parser.py` \u2014 make `lang` an explicit named parameter on `VisionFigureParser.__init__`. The type system now catches the omission, and the value is normalized via the existing `_normalize_vision_language` helper (mirroring the wrappers' own handling) for consistency. `**kwargs.get(\"lang\")` is kept as a fallback so older callers that don't pass `lang` keep working.\n\n```python\ndef __init__(self, vision_model, figures_data, *args, lang=\"English\", **kwargs):\n    ...\n    self.language = _normalize_vision_language(lang) or kwargs.get(\"lang\") or \"English\"\n```\n\nNo behavior change for any existing call site.\n\n## Tests\n\n`test/unit_test/deepdoc/parser/test_figure_parser.py` \u2014 the existing `test_vision_figure_parser_passes_dataset_language_to_prompt[language]` parametrized test already covers the named-parameter forward path; it pins `vision_llm_figure_describe_prompt` is called with the normalized language. `test_figure_wrappers_pass_dataset_language_to_model_and_parser` covers the three wrappers' end-to-end path.\n\nDiff: +9 / -2 across 1 file. `mergeable: MERGEABLE`.\n"