### PR TITLE
fix(naive): do not route vision layout models to MinerU

### DIFF
--- a/common/parser_config_utils.py
+++ b/common/parser_config_utils.py
@@ -14,7 +14,15 @@
 #  limitations under the License.
 #
 
+import re
 from typing import Any
+
+_MODEL_ID_RE = re.compile(r"^[0-9a-f]{32}$", re.I)
+
+
+def is_tenant_model_id(value: Any) -> bool:
+    return isinstance(value, str) and bool(_MODEL_ID_RE.match(value.strip()))
+
 
 # Parser-specific option keys. ``_has_mineru_options`` uses these to detect
 # whether the operator clearly intended the MinerU parser (issue #17114).
@@ -29,9 +37,10 @@ MINERU_OPTION_KEYS: tuple[str, ...] = (
 def has_mineru_options(parser_config: Any) -> bool:
     """Return True if parser_config carries any MinerU-specific option.
 
-    Used by the PDF dispatch in :mod:`rag.app.naive` to recover from a
-    misconfigured ``layout_recognize`` value (a stale TenantModel id rather
-    than the ``"MinerU"`` keyword) — see issue #17114.
+    Used by the PDF dispatch in :mod:`rag.app.naive` together with
+    :func:`is_tenant_model_id` to recover only from a *stale* TenantModel id
+    (issue #17114). Vision-LLM composite names with leftover mineru_* form
+    defaults must not trigger that recovery.
     """
     if not isinstance(parser_config, dict):
         return False

--- a/rag/app/naive.py
+++ b/rag/app/naive.py
@@ -49,7 +49,7 @@ from deepdoc.parser.docling_parser import DoclingParser
 from deepdoc.parser.monkeyocrv2_parser import MonkeyOCRv2Parser
 from deepdoc.parser.tcadp_parser import TCADPParser
 from common.float_utils import normalize_overlapped_percent
-from common.parser_config_utils import has_mineru_options, normalize_layout_recognizer
+from common.parser_config_utils import has_mineru_options, is_tenant_model_id, normalize_layout_recognizer
 from common.text_utils import normalize_arabic_presentation_forms
 from rag.nlp import (
     concat_img,
@@ -214,25 +214,29 @@ def _dispatch_pdf_parser(parser_config: dict, opendataloader_llm_name=None, layo
     name = layout_recognizer.strip().lower()
     parser = PARSERS.get(name, by_plaintext)
 
-    # Closes #17114: when the document's layout_recognize is a model id
-    # (e.g. a TenantModel UUID) that does not match any known parser name,
-    # the previous dispatch fell through to by_plaintext, which tried to
-    # resolve the id as an IMAGE2TEXT vision model and failed with
-    # ``Provider <empty> not found for model <id>``. If mineru-specific
-    # options are set in parser_config, the operator clearly intended the
-    # MinerU parser, so route there instead and surface a clear log line
-    # rather than masking the misconfiguration silently.
-    # Guard: only fall back when the parser name is NOT a known keyword
-    # (e.g. "DeepDOC", "Plain Text"). A configuration like
-    # ``{"layout_recognize": "Plain Text", "mineru_lang": "English"}``
-    # must keep honoring PlainText, not be silently rerouted to MinerU.
-    if name not in PARSERS and parser is by_plaintext and has_mineru_options(parser_config):
+    # Closes #17114: a *stale* TenantModel UUID (model deleted) that does not
+    # match any known parser name used to fall through to by_plaintext, which
+    # tried to resolve the id as an IMAGE2TEXT vision model and crashed.
+    # If mineru_* options are set, recover by routing to by_mineru.
+    #
+    # Only apply this for unresolved tenant_model ids. Frontend defaults often
+    # persist mineru_* even when the operator selected a vision LLM
+    # (e.g. ``qwen3.6-plus@tongyi@Tongyi-Qianwen``); those composite names must
+    # keep going to by_plaintext, not be silently rerouted to MinerU.
+    # Same for known keywords: ``{"layout_recognize": "Plain Text", "mineru_lang": ...}``.
+    if (
+        name not in PARSERS
+        and parser is by_plaintext
+        and has_mineru_options(parser_config)
+        and is_tenant_model_id(str(layout_recognizer).strip())
+    ):
         logging.warning(
-            "[naive] layout_recognize=%r does not match a known parser; falling back to MinerU because mineru_* options are set (see issue #17114).",
+            "[naive] layout_recognize=%r is an unresolved tenant model id; falling back to MinerU because mineru_* options are set (see issue #17114).",
             layout_recognizer,
         )
         parser = by_mineru
         name = "mineru"
+
 
     return parser, name, layout_recognizer, opendataloader_llm_name, parser_model_name
 

--- a/test/unit_test/rag/test_naive_dispatch.py
+++ b/test/unit_test/rag/test_naive_dispatch.py
@@ -42,6 +42,7 @@ import pytest
 from common.parser_config_utils import (
     MINERU_OPTION_KEYS,
     has_mineru_options,
+    is_tenant_model_id,
     normalize_layout_recognizer,
 )
 
@@ -204,7 +205,7 @@ def naive_module():
         _stub("deepdoc.parser.tcadp_parser", TCADPParser=_Parser)
         _stub("deepdoc.parser.utils", extract_pdf_outlines=lambda *a, **k: [])
 
-        _stub("common.parser_config_utils", normalize_layout_recognizer=normalize_layout_recognizer, MINERU_OPTION_KEYS=MINERU_OPTION_KEYS, has_mineru_options=has_mineru_options)
+        _stub("common.parser_config_utils", normalize_layout_recognizer=normalize_layout_recognizer, MINERU_OPTION_KEYS=MINERU_OPTION_KEYS, has_mineru_options=has_mineru_options, is_tenant_model_id=is_tenant_model_id)
         _stub("common.float_utils", normalize_overlapped_percent=lambda x: x)
         _stub("common.text_utils", normalize_arabic_presentation_forms=lambda x: x)
         _stub("common.token_utils", num_tokens_from_string=lambda s: len((s or "").split()))
@@ -354,6 +355,25 @@ def test_dispatch_falls_back_to_mineru_only_for_unknown_layout_recognize(naive_m
     # The fallback branch reassigns parser=by_mineru directly (not via
     # PARSERS["mineru"]), so identify it by the function name.
     assert parser.__name__ == "by_mineru"
+
+
+def test_dispatch_does_not_fall_back_to_mineru_for_vision_composite_name(naive_module):
+    """A resolved vision LLM composite name with leftover mineru_* form
+    defaults must keep routing to by_plaintext (vision parser), not MinerU."""
+    vision_ref = "qwen3.6-plus@tongyi@Tongyi-Qianwen"
+    parser, name, lr, _op, _model = _dispatch(
+        naive_module,
+        vision_ref,
+        {
+            "mineru_parse_method": "auto",
+            "mineru_formula_enable": True,
+            "mineru_table_enable": True,
+            "mineru_lang": "English",
+        },
+    )
+    assert name == vision_ref.lower()
+    assert lr == vision_ref
+    assert parser is _ByPlaintext
 
 
 # CodeRabbit review #4: layout_recognize_override preserves parser_model_name.

--- a/web/src/components/chunk-method-dialog/index.tsx
+++ b/web/src/components/chunk-method-dialog/index.tsx
@@ -245,10 +245,16 @@ export function ChunkMethodDialog({
   const showAutoKeywords = useShowAutoKeywords();
 
   async function onSubmit(data: z.infer<typeof FormSchema>) {
-    const parserConfig = data.parser_config;
+    const parserConfig = { ...data.parser_config };
     const imageTableContextWindow = Number(
       parserConfig?.image_table_context_window || 0,
     );
+    if (!isMineruSelected) {
+      delete parserConfig.mineru_parse_method;
+      delete parserConfig.mineru_formula_enable;
+      delete parserConfig.mineru_table_enable;
+      delete parserConfig.mineru_lang;
+    }
     const nextData = {
       ...data,
       parser_id: data.parser_id || '',

--- a/web/src/components/chunk-method-dialog/use-default-parser-values.ts
+++ b/web/src/components/chunk-method-dialog/use-default-parser-values.ts
@@ -34,10 +34,6 @@ export function useDefaultParserValues() {
       auto_questions: 0,
       html4excel: false,
       image_table_context_window: 0,
-      mineru_parse_method: 'auto',
-      mineru_formula_enable: true,
-      mineru_table_enable: true,
-      mineru_lang: 'English',
       raptor: {
         use_raptor: false,
         prompt: t('knowledgeConfiguration.promptText'),

--- a/web/src/hooks/parser-config-utils.ts
+++ b/web/src/hooks/parser-config-utils.ts
@@ -28,6 +28,17 @@ export const isPipelineParserConfig = (
   return Object.keys(parserConfig).some((key) => key.includes(':'));
 };
 
+const MinerUOptionKeys = [
+  'mineru_parse_method',
+  'mineru_formula_enable',
+  'mineru_table_enable',
+  'mineru_lang',
+] as const;
+
+const isMinerULayoutRecognize = (layoutRecognize: unknown): boolean =>
+  typeof layoutRecognize === 'string' &&
+  layoutRecognize.toLowerCase().includes('mineru');
+
 /**
  * Normalizes parser configuration before it is sent to the API.
  * @param parserConfig - The parser configuration object
@@ -56,6 +67,13 @@ export const normalizeParserConfig = (
   } = parserConfig;
   delete additionalParserConfig.graphrag;
   delete additionalParserConfig.raptor;
+  // Do not persist MinerU-only options when another layout recognizer is
+  // selected; leftover mineru_* keys used to falsely trigger MinerU fallback.
+  if (!isMinerULayoutRecognize(layout_recognize)) {
+    for (const key of MinerUOptionKeys) {
+      delete additionalParserConfig[key];
+    }
+  }
   return {
     auto_keywords,
     auto_questions,

--- a/web/src/pages/dataset/setting/python/index.tsx
+++ b/web/src/pages/dataset/setting/python/index.tsx
@@ -63,11 +63,6 @@ export default function DatasetSettings() {
         topn_tags: 3,
         image_table_context_window: 0,
         overlapped_percent: 0,
-        // MinerU-specific defaults
-        mineru_parse_method: 'auto',
-        mineru_formula_enable: true,
-        mineru_table_enable: true,
-        mineru_lang: 'English',
         metadata: {
           type: 'object',
           properties: {},


### PR DESCRIPTION
## Summary
- Narrow the #17114 `mineru_*` PDF dispatch fallback so it only applies to unresolved tenant model ids, not resolved vision LLM composite names like `qwen@tongyi@Tongyi-Qianwen`.
- Stop persisting MinerU form defaults when MinerU is not selected, which previously falsely triggered the fallback.

## Test plan
- [ ] Unit: `pytest test/unit_test/rag/test_naive_dispatch.py` (includes new vision composite-name case)
- [ ] Select a vision/image2text model as layout_recognize on a PDF, parse, confirm progress logs use VisionParser / plaintext path rather than `[MinerU]`
- [ ] Select MinerU (or keep a stale MinerU model id with `mineru_*` options) and confirm MinerU path still works
