### PR TITLE
fix(parser): flush pending text before table/image chunks in _build_cks

### DIFF
--- a/rag/nlp/__init__.py
+++ b/rag/nlp/__init__.py
@@ -1645,6 +1645,12 @@ def concat_img(img1, img2):
 
 
 def _build_cks(sections, delimiter):
+    """Split ``(text, image, table)`` sections into typed chunks.
+
+    Text is buffered and split on the parsed ``delimiter`` field; each table
+    or image section becomes its own chunk. Returns
+    ``(cks, tables, images, has_custom)``.
+    """
     cks = []
     tables = []
     images = []
@@ -1659,6 +1665,29 @@ def _build_cks(sections, delimiter):
     pattern = r"(%s)" % split_pattern if split_pattern else ""
 
     seg = ""
+
+    def _flush_seg():
+        """Emit pending text before a table/image chunk is appended.
+
+        Plain text is buffered in ``seg`` and only flushed when a delimiter
+        matches, whereas table/image chunks are appended immediately. Without
+        this flush the buffered text lands *after* the table/image, breaking
+        document order and swapping context_above / context_below in
+        _add_context() (which decides "above"/"below" by array position).
+        """
+        nonlocal seg
+        if seg and seg.strip():
+            s = seg.strip()
+            cks.append(
+                {
+                    "text": s,
+                    "image": None,
+                    "ck_type": "text",
+                    "tk_nums": num_tokens_from_string(s),
+                }
+            )
+        seg = ""
+
     for text, image, table in sections:
         # normalize text: ensure string and prepend newline for continuity
         if not text:
@@ -1668,6 +1697,7 @@ def _build_cks(sections, delimiter):
 
         if table:
             # table chunk
+            _flush_seg()
             ck_text = text + str(table)
             idx = len(cks)
             cks.append(
@@ -1683,6 +1713,7 @@ def _build_cks(sections, delimiter):
 
         if image:
             # image chunk (text kept as-is for context)
+            _flush_seg()
             idx = len(cks)
             cks.append(
                 {


### PR DESCRIPTION
## Summary

Fixes #19520.

`_build_cks()` buffered plain text in `seg` (emitted only when a delimiter matches) but appended table/image chunks **immediately**. So when a paragraph was immediately followed by a table/image, the buffered text landed **after** the table — chunk order no longer matched the document order.

It also swapped `context_above` / `context_below` produced by `_add_context()`, which decides "above"/"below" purely by array position: a table's own caption ended up in `context_below` instead of `context_above`.

## Change

Flush `seg` before appending a table/image chunk:

```python
def _flush_seg():
    nonlocal seg
    if seg and seg.strip():
        s = seg.strip()
        cks.append({"text": s, "image": None, "ck_type": "text",
                    "tk_nums": num_tokens_from_string(s)})
    seg = ""

...
    if table:
        _flush_seg()
        ck_text = text + str(table)
        idx = len(cks)          # taken after the flush → tables/images stay correct
        ...
    if image:
        _flush_seg()
        idx = len(cks)
        ...
```

Also adds a docstring to `_build_cks` and to the new helper.

## Verification

```python
sections = [("表格标题", None, None),
            ("", None, "<table><tr><td>x</td></tr></table>"),
            ("后续段落", None, None)]
_build_cks(sections, "\n")
```

| | before | after |
|---|---|---|
| chunk order | `[table, text"表格标题", text"后续段落"]` | `[text"表格标题", table, text"后续段落"]` |
| `tables` | `[0]` | `[1]` |

On a real document (121 sections, 6 tables) every table chunk was shifted one position earlier before the fix; afterwards they line up with the document order, and a table's caption is correctly reported as `context_above` instead of `context_below`.

## Notes

- Only affects `naive_merge_docx()`.
- No behaviour change for documents without tables/images.
