### PR TITLE
fix(ollama): disable reasoning for vision descriptions

### DIFF
--- a/internal/entity/models/ollama.go
+++ b/internal/entity/models/ollama.go
@@ -56,6 +56,9 @@ func (o *OllamaModel) Name() string {
 func buildOllamaRequestBody(cfg *ChatConfig, modelName string, messages []Message, stream bool) map[string]any {
 	reqBody := buildRequestBody(cfg, modelName, messages, stream)
 	reqBody["messages"] = buildOllamaMessages(messages)
+	if cfg != nil && cfg.Thinking != nil {
+		reqBody["think"] = *cfg.Thinking
+	}
 	return reqBody
 }
 
@@ -164,10 +167,6 @@ func (o *OllamaModel) ChatWithMessages(ctx context.Context, modelName string, me
 			if strings.HasPrefix(strings.ToLower(modelName), "gpt-oss") {
 				reqBody["think"] = *chatModelConfig.Effort
 			}
-		} else if chatModelConfig.Thinking != nil {
-			if *chatModelConfig.Thinking {
-				reqBody["think"] = true
-			}
 		}
 	}
 
@@ -201,10 +200,6 @@ func (o *OllamaModel) ChatStreamlyWithSender(ctx context.Context, modelName stri
 		if modelConfig.Effort != nil && *modelConfig.Effort != "" {
 			if strings.HasPrefix(strings.ToLower(modelName), "gpt-oss") {
 				reqBody["think"] = *modelConfig.Effort
-			}
-		} else if modelConfig.Thinking != nil {
-			if *modelConfig.Thinking {
-				reqBody["think"] = true
 			}
 		}
 	}

--- a/internal/entity/models/ollama_test.go
+++ b/internal/entity/models/ollama_test.go
@@ -136,6 +136,51 @@ func TestOllamaStreamingChatMapsMultimodalImages(t *testing.T) {
 	}
 }
 
+func TestOllamaThinkingPayloadTriState(t *testing.T) {
+	withSSRFBypass(t)
+	for _, tc := range []struct {
+		name string
+		cfg  *ChatConfig
+		want any
+	}{
+		{name: "nil omitted"},
+		{name: "false", cfg: &ChatConfig{Thinking: boolPointer(false)}, want: false},
+		{name: "true", cfg: &ChatConfig{Thinking: boolPointer(true)}, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var body map[string]interface{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				_, _ = io.WriteString(w, `{"message":{"content":"ok","thinking":""}}`)
+			}))
+			defer srv.Close()
+
+			if _, err := newOllamaForChatTest(srv.URL).ChatWithMessages(t.Context(), "llava", []Message{{Role: "user", Content: "hello"}}, &APIConfig{}, tc.cfg, nil); err != nil {
+				t.Fatalf("ChatWithMessages: %v", err)
+			}
+			got, exists := body["think"]
+			if tc.want == nil {
+				if exists {
+					t.Fatalf("think=%v, want omitted", got)
+				}
+				return
+			}
+			if !exists || got != tc.want {
+				t.Fatalf("think=%v, want %v", got, tc.want)
+			}
+			if options, exists := body["options"]; exists {
+				if optionsMap, ok := options.(map[string]interface{}); ok {
+					if _, nested := optionsMap["think"]; nested {
+						t.Fatal("think must not be nested in options")
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestOllamaListModels(t *testing.T) {
 	withSSRFBypass(t)
 	ctx := t.Context()

--- a/internal/entity/models/ollama_test.go
+++ b/internal/entity/models/ollama_test.go
@@ -181,6 +181,36 @@ func TestOllamaThinkingPayloadTriState(t *testing.T) {
 	}
 }
 
+func TestOllamaThinkingOverridesEffortOnlyForGPTOSS(t *testing.T) {
+	withSSRFBypass(t)
+	for _, tc := range []struct {
+		name, model string
+		want        any
+	}{
+		{name: "gpt-oss uses effort", model: "gpt-oss:20b", want: "high"},
+		{name: "other model keeps thinking", model: "llava", want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var body map[string]interface{}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request: %v", err)
+				}
+				_, _ = io.WriteString(w, `{"message":{"content":"ok","thinking":""}}`)
+			}))
+			defer srv.Close()
+			thinking := false
+			effort := "high"
+			if _, err := newOllamaForChatTest(srv.URL).ChatWithMessages(t.Context(), tc.model, []Message{{Role: "user", Content: "hello"}}, &APIConfig{}, &ChatConfig{Thinking: &thinking, Effort: &effort}, nil); err != nil {
+				t.Fatalf("ChatWithMessages: %v", err)
+			}
+			if got := body["think"]; got != tc.want {
+				t.Fatalf("think=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestOllamaListModels(t *testing.T) {
 	withSSRFBypass(t)
 	ctx := t.Context()

--- a/internal/ingestion/component/vision_enhancement.go
+++ b/internal/ingestion/component/vision_enhancement.go
@@ -368,5 +368,6 @@ func defaultVisionChatInvoker(
 	chatCtx, cancel := context.WithTimeout(ctx, visionChatTimeout)
 	defer cancel()
 	vision := true
-	return driver.ChatWithMessages(chatCtx, modelName, messages, apiConfig, &modelModule.ChatConfig{Vision: &vision}, nil)
+	thinking := false
+	return driver.ChatWithMessages(chatCtx, modelName, messages, apiConfig, &modelModule.ChatConfig{Vision: &vision, Thinking: &thinking}, nil)
 }

--- a/internal/ingestion/component/vision_enhancement.go
+++ b/internal/ingestion/component/vision_enhancement.go
@@ -368,6 +368,10 @@ func defaultVisionChatInvoker(
 	chatCtx, cancel := context.WithTimeout(ctx, visionChatTimeout)
 	defer cancel()
 	vision := true
-	thinking := false
-	return driver.ChatWithMessages(chatCtx, modelName, messages, apiConfig, &modelModule.ChatConfig{Vision: &vision, Thinking: &thinking}, nil)
+	config := &modelModule.ChatConfig{Vision: &vision}
+	if _, ok := driver.(*modelModule.OllamaModel); ok {
+		thinking := false
+		config.Thinking = &thinking
+	}
+	return driver.ChatWithMessages(chatCtx, modelName, messages, apiConfig, config, nil)
 }

--- a/internal/ingestion/component/vision_enhancement_test.go
+++ b/internal/ingestion/component/vision_enhancement_test.go
@@ -839,6 +839,7 @@ type deadlineCaptureDriver struct {
 	modelModule.ModelDriver
 	hasDeadline bool
 	remaining   time.Duration
+	config      *modelModule.ChatConfig
 }
 
 func (d *deadlineCaptureDriver) ChatWithMessages(
@@ -846,11 +847,12 @@ func (d *deadlineCaptureDriver) ChatWithMessages(
 	_ string,
 	_ []modelModule.Message,
 	_ *modelModule.APIConfig,
-	_ *modelModule.ChatConfig,
+	config *modelModule.ChatConfig,
 	_ *common.ModelUsage,
 ) (*modelModule.ChatResponse, error) {
 	deadline, ok := ctx.Deadline()
 	d.hasDeadline = ok
+	d.config = config
 	if ok {
 		d.remaining = time.Until(deadline)
 	}
@@ -868,5 +870,11 @@ func TestDefaultVisionChatInvoker_AppliesDeadline(t *testing.T) {
 	}
 	if drv.remaining <= 0 || drv.remaining > visionChatTimeout+time.Second {
 		t.Fatalf("deadline remaining = %v, want ~%v", drv.remaining, visionChatTimeout)
+	}
+	if drv.config == nil || drv.config.Vision == nil || !*drv.config.Vision {
+		t.Fatal("vision chat must enable vision")
+	}
+	if drv.config.Thinking == nil || *drv.config.Thinking {
+		t.Fatal("vision chat must disable thinking")
 	}
 }

--- a/internal/ingestion/component/vision_enhancement_test.go
+++ b/internal/ingestion/component/vision_enhancement_test.go
@@ -874,7 +874,7 @@ func TestDefaultVisionChatInvoker_AppliesDeadline(t *testing.T) {
 	if drv.config == nil || drv.config.Vision == nil || !*drv.config.Vision {
 		t.Fatal("vision chat must enable vision")
 	}
-	if drv.config.Thinking == nil || *drv.config.Thinking {
-		t.Fatal("vision chat must disable thinking")
+	if drv.config.Thinking != nil {
+		t.Fatal("non-Ollama vision chat must preserve provider thinking default")
 	}
 }

--- a/internal/service/ask_service_test.go
+++ b/internal/service/ask_service_test.go
@@ -225,6 +225,17 @@ func TestAskService_TemperatureFromLLMSetting(t *testing.T) {
 	}
 }
 
+func TestAskService_DisablesThinkingForSummary(t *testing.T) {
+	ret := &fakeRetriever{result: &RetrievalTestResponse{
+		Chunks: []map[string]interface{}{{"id": "c1", "content_with_weight": "chunk", "docnm_kwd": "Doc", "kb_id": "kb1", "doc_id": "d1"}},
+	}}
+	llm := &capturingStreamLLM{fakeStreamLLM: fakeStreamLLM{chunks: []string{"answer"}}}
+	collect(NewAskService(ret, nil, 0, 0).Stream(t.Context(), llm, "user1", "test", []string{"kb1"}))
+	if llm.gotConfig == nil || llm.gotConfig.Thinking == nil || *llm.gotConfig.Thinking {
+		t.Fatalf("summary must explicitly disable thinking, got %+v", llm.gotConfig)
+	}
+}
+
 func TestAskService_TemperatureDisabledUsesDefault(t *testing.T) {
 	ret := &fakeRetriever{result: &RetrievalTestResponse{
 		Chunks: []map[string]interface{}{

--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -831,6 +831,7 @@ class OllamaCV(Base):
                 model=self.model_name,
                 prompt=prompt[0]["content"],
                 images=[image],
+                think=False,
             )
             ans = response["response"].strip()
             return ans, 128
@@ -844,6 +845,7 @@ class OllamaCV(Base):
                 model=self.model_name,
                 prompt=vision_prompt[0]["content"],
                 images=[image],
+                think=False,
             )
             ans = response["response"].strip()
             return ans, 128


### PR DESCRIPTION
Vision calls now explicitly disable Ollama reasoning. Regular chat keeps its existing thinking behavior.
based on #17031