### PR TITLE
Fix: The text in the SelectWithSearch dropdown menu is obscured by the checkmark icon.

### DIFF
--- a/web/src/components/originui/select-with-search.tsx
+++ b/web/src/components/originui/select-with-search.tsx
@@ -344,7 +344,7 @@ export const SelectWithSearch = forwardRef<
                               : 'combobox-option'
                           }
                           className={cn(
-                            "relative flex flex-col min-h-10 data-[selected='true']:bg-card-soft",
+                            "relative flex flex-col min-h-10 pr-8 data-[selected='true']:bg-card-soft",
                             option.description
                               ? 'items-start gap-1'
                               : 'justify-center items-start',
@@ -384,7 +384,7 @@ export const SelectWithSearch = forwardRef<
                           : 'combobox-option'
                       }
                       className={cn(
-                        "relative flex flex-col min-h-10 mb-1 data-[selected='true']:bg-card-soft",
+                        "relative flex flex-col min-h-10 mb-1 pr-8 data-[selected='true']:bg-card-soft",
                         group.description
                           ? 'items-start gap-1'
                           : 'justify-center items-start',

--- a/web/src/pages/agent/canvas/node/note-node/index.tsx
+++ b/web/src/pages/agent/canvas/node/note-node/index.tsx
@@ -75,7 +75,7 @@ function NoteNode({
         <section className="px-2 py-1 flex gap-2 items-center note-drag-handle rounded-t border-t-2 border-state-warning">
           <NotebookPen className="size-4" />
           <Form {...nameForm}>
-            <form className="flex-1">
+            <form onSubmit={nameForm.handleSubmit(() => {})} className="flex-1">
               <FormField
                 control={nameForm.control}
                 name="name"


### PR DESCRIPTION
### Summary

Fix: The text in the SelectWithSearch dropdown menu is obscured by the checkmark icon.