### PR TITLE
fix(memories): derive filter options from page list query to prevent stale filters

### DIFF
--- a/web/src/pages/memories/hooks.ts
+++ b/web/src/pages/memories/hooks.ts
@@ -314,35 +314,50 @@ export const useRenameMemory = () => {
   };
 };
 
-export function useSelectFilters() {
+/**
+ * Build the filter facet collections for the memory list page from the
+ * memory items that are already loaded by the page's list query.
+ *
+ * The filters must be derived from the same query data that renders the
+ * memory cards so that creating, updating or deleting a memory and
+ * refetching the list refreshes the cards and the filter options in
+ * lockstep. Firing a second list query here creates an independent react-
+ * query observer whose key diverges from the page query whenever a search
+ * keyword or a filter is active, leaving the filter options stale after a
+ * memory is created.
+ *
+ * @param memoryList - The memory items of the currently loaded list page.
+ * @returns The filter collections consumed by ListFilterBar.
+ *
+ * @example
+ * const { data: list } = useFetchMemoryList();
+ * const { filters } = useSelectFilters(list?.data?.memory_list ?? []);
+ */
+export function useSelectFilters(memoryList: IMemory[]) {
   const { t } = useTranslation();
-  const { data: res } = useFetchMemoryList();
-  const data = res?.data;
 
-  const memoryType = useMemo(() => {
-    return groupListByArray(data?.memory_list ?? [], 'memory_type');
-  }, [data?.memory_list]);
-  const storageType = useMemo(() => {
-    return groupListByType(
-      data?.memory_list ?? [],
+  const filters: FilterCollection[] = useMemo(() => {
+    const memoryType = groupListByArray(memoryList, 'memory_type');
+    const storageType = groupListByType(
+      memoryList,
       'storage_type',
       'storage_type',
     );
-  }, [data?.memory_list]);
 
-  const filters: FilterCollection[] = [
-    buildOwnersFilter(data?.memory_list ?? [], 'owner_name', t('common.owner')),
-    {
-      field: 'memoryType',
-      list: memoryType,
-      label: t('memories.memoryType'),
-    },
-    {
-      field: 'storageType',
-      list: storageType,
-      label: t('memory.config.storageType'),
-    },
-  ];
+    return [
+      buildOwnersFilter(memoryList, 'owner_name', t('common.owner')),
+      {
+        field: 'memoryType',
+        list: memoryType,
+        label: t('memories.memoryType'),
+      },
+      {
+        field: 'storageType',
+        list: storageType,
+        label: t('memory.config.storageType'),
+      },
+    ];
+  }, [memoryList, t]);
 
   return { filters };
 }

--- a/web/src/pages/memories/index.tsx
+++ b/web/src/pages/memories/index.tsx
@@ -70,7 +70,7 @@ export default function MemoryList() {
   });
 
   const [searchUrl, setMemoryUrl] = useSearchParams();
-  const { filters } = useSelectFilters();
+  const { filters } = useSelectFilters(list?.data?.memory_list ?? []);
   const isCreate = searchUrl.get('isCreate') === 'true';
   useEffect(() => {
     if (isCreate) {


### PR DESCRIPTION
### Summary

useSelectFilters previously fired its own useFetchMemoryList query, creating a second react-query observer whose cache key diverged from the page query as soon as a search keyword or filter was active. Creating, updating or deleting a memory refreshed the page list but left the filter facets stale.

Refactor useSelectFilters to accept the memory list as a parameter and pass list.data.memory_list from the page's own query at the call site, so both the cards and the filter options are driven by a single observer.