### PR TITLE
fix(api): authorize the dataset document download route by tenant in the Go API

### DIFF
--- a/internal/handler/document.go
+++ b/internal/handler/document.go
@@ -1113,6 +1113,12 @@ func isValidHTTPURL(raw string) bool {
 }
 
 func (h *DocumentHandler) DownloadDocument(c *gin.Context) {
+	user, errorCode, errorMessage := GetUser(c)
+	if errorCode != common.CodeSuccess {
+		common.ErrorWithCode(c, errorCode, errorMessage)
+		return
+	}
+
 	datasetID := c.Param("dataset_id")
 	docID := c.Param("document_id")
 
@@ -1125,6 +1131,18 @@ func (h *DocumentHandler) DownloadDocument(c *gin.Context) {
 		return
 	}
 	ctx := c.Request.Context()
+	// Authorize the caller before serving file bytes. The sibling routes on
+	// this dataset (PATCH/DELETE documents, chunks, metadata) all gate on
+	// datasetService.Accessible, and the Python reference
+	// (document_api.py download) checks KnowledgebaseService.accessible and
+	// DocumentService.accessible; without this, any logged-in user could
+	// download any tenant's document by supplying its dataset and document
+	// ids. Answer exactly like the missing-document case so existence is
+	// not leaked either.
+	if !h.datasetService.Accessible(ctx, datasetID, user.ID) {
+		common.ResponseWithCodeData(c, common.CodeDataError, nil, "document not found")
+		return
+	}
 	res, err := h.documentService.DownloadDocument(ctx, datasetID, docID)
 
 	if err != nil {

--- a/internal/handler/document_test.go
+++ b/internal/handler/document_test.go
@@ -1887,13 +1887,35 @@ func TestGetDocumentPreview_StorageErrorGenericMessage(t *testing.T) {
 	}
 }
 
-func TestDownloadDocument_Success(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DocumentHandler{
+// downloadHandlerWithAccessDB wires the real dataset permission check against
+// the seeded in-memory DB (ds-1 is owned by tenant-1 / user-1) so the tests
+// exercise the tenant gate on the download route.
+func downloadHandlerWithAccessDB(t *testing.T) *DocumentHandler {
+	t.Helper()
+	db := setupHandlerAccessDB(t)
+	orig := dao.DB
+	dao.DB = db
+	t.Cleanup(func() { dao.DB = orig })
+	return &DocumentHandler{
 		documentService: &fakeDocumentService{},
+		datasetService:  dataset.NewDatasetService(),
 	}
-	c, w := setupGinContextWithUser("GET", "/api/v1/datasets/ds-1/documents/doc-1", "")
-	c.Params = gin.Params{{Key: "dataset_id", Value: "ds-1"}, {Key: "document_id", Value: "doc-1"}}
+}
+
+func downloadContextAs(userID, datasetID, docID string) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/api/v1/datasets/"+datasetID+"/documents/"+docID, nil)
+	c.Set("user", &entity.User{ID: userID})
+	c.Set("user_id", userID)
+	c.Params = gin.Params{{Key: "dataset_id", Value: datasetID}, {Key: "document_id", Value: docID}}
+	return c, w
+}
+
+func TestDownloadDocument_Success(t *testing.T) {
+	h := downloadHandlerWithAccessDB(t)
+	c, w := downloadContextAs("user-1", "ds-1", "doc-1")
 
 	h.DownloadDocument(c)
 
@@ -1909,12 +1931,8 @@ func TestDownloadDocument_Success(t *testing.T) {
 }
 
 func TestDownloadDocument_NotFound(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	h := &DocumentHandler{
-		documentService: &fakeDocumentService{},
-	}
-	c, w := setupGinContextWithUser("GET", "/api/v1/datasets/ds-1/documents/not-found", "")
-	c.Params = gin.Params{{Key: "dataset_id", Value: "ds-1"}, {Key: "document_id", Value: "not-found"}}
+	h := downloadHandlerWithAccessDB(t)
+	c, w := downloadContextAs("user-1", "ds-1", "not-found")
 
 	h.DownloadDocument(c)
 
@@ -1925,5 +1943,29 @@ func TestDownloadDocument_NotFound(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["code"] != float64(common.CodeDataError) {
 		t.Fatalf("expected code %d, got %v", common.CodeDataError, resp["code"])
+	}
+}
+
+// A logged-in user who is not a member of the dataset's tenant must not be
+// able to download its documents, and must not learn whether they exist.
+func TestDownloadDocument_ForeignUserRejected(t *testing.T) {
+	h := downloadHandlerWithAccessDB(t)
+	c, w := downloadContextAs("user-2", "ds-1", "doc-1")
+
+	h.DownloadDocument(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 envelope, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "document data") {
+		t.Fatalf("document bytes must not be served to a foreign user")
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != float64(common.CodeDataError) {
+		t.Fatalf("expected code %d, got %v", common.CodeDataError, resp["code"])
+	}
+	if resp["message"] != "document not found" {
+		t.Fatalf("foreign user must get the same message as a missing document, got %v", resp["message"])
 	}
 }


### PR DESCRIPTION
### Summary

Fixes #19542

`GET /api/v1/datasets/:dataset_id/documents/:document_id` (`DocumentHandler.DownloadDocument`) never consulted the caller: it passed the two ids straight to `documentService.DownloadDocument`, whose only check is `doc.KbID == datasetID`, so any logged-in user could download any tenant's document file by supplying its dataset and document ids. The sibling document routes gate on `datasetService.Accessible`, and the Python reference for this route (`document_api.py` `download`) checks `KnowledgebaseService.accessible` and `DocumentService.accessible` before reading storage; the Go port dropped both.

Changes:
- `DownloadDocument` resolves the user with `GetUser` and requires `datasetService.Accessible(ctx, datasetID, user.ID)` before calling the service. A rejected caller receives the same `CodeDataError` / `"document not found"` envelope a missing document produces (the Python route's `get_data_error_result`), so the response does not reveal whether the document exists.

Tests:
- `TestDownloadDocument_ForeignUserRejected` runs the real handler with a real `DatasetService` against the seeded in-memory access DB (`ds-1` owned by `tenant-1`/`user-1`) as `user-2` and asserts no bytes are served and the envelope matches the missing-document case. It fails on `main` (the body is `document data`).
- `TestDownloadDocument_Success` / `_NotFound` now run through the same wiring as the owner, so the gate is exercised on the happy path too.
- `CGO_ENABLED=0 go test ./internal/handler/`, `go vet ./internal/handler/` and `gofmt` pass locally.

Written with the help of an AI coding agent (Claude Code); reviewed by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcXuE1qS3V3CL2AbMpsMk3
