### PR TITLE
fix(ssrf): re-validate and pin every redirect hop in `PinnedHTTPClient`

### DIFF
--- a/internal/utility/ssrf.go
+++ b/internal/utility/ssrf.go
@@ -314,6 +314,13 @@ var PinnedHTTPClient = func(hostname, resolvedIP string, timeout time.Duration) 
 			if len(via) >= maxPinnedRedirects {
 				return fmt.Errorf("stopped after %d redirects", maxPinnedRedirects)
 			}
+			// Never follow an HTTPS -> HTTP downgrade: the request may carry
+			// credentials (Authorization, API-key headers rendered for MCP
+			// servers) that would otherwise be replayed over cleartext.
+			if len(via) > 0 && via[0].URL != nil && strings.EqualFold(via[0].URL.Scheme, "https") &&
+				!strings.EqualFold(req.URL.Scheme, "https") {
+				return fmt.Errorf("redirect to %s blocked: https to http downgrade", req.URL.Redacted())
+			}
 			host, ip, err := AssertURLSafe(req.URL.String())
 			if err != nil {
 				return fmt.Errorf("redirect to %s blocked: %w", req.URL.Redacted(), err)

--- a/internal/utility/ssrf.go
+++ b/internal/utility/ssrf.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -242,11 +243,47 @@ var AssertURLSchemeSafe = func(rawURL string) error {
 	return nil
 }
 
+// maxPinnedRedirects mirrors net/http's default redirect budget.
+const maxPinnedRedirects = 10
+
+// pinTable maps validated hostnames to the IP AssertURLSafe resolved for
+// them. It grows as redirects are followed so every hop is dialed pinned.
+type pinTable struct {
+	mu  sync.Mutex
+	ips map[string]string
+}
+
+func (p *pinTable) set(hostname, ip string) {
+	if hostname == "" || ip == "" {
+		return
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.ips[hostname] = ip
+}
+
+func (p *pinTable) get(hostname string) (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	ip, ok := p.ips[hostname]
+	return ip, ok
+}
+
 // PinnedHTTPClient returns an HTTP client whose Transport rewrites every
 // outbound dial for hostname:port to resolvedIP:port, closing the TOCTOU
 // window between AssertURLSafe and the actual TCP connection. Pins are
 // scoped to this client only.
+//
+// Redirects are re-validated: net/http follows up to ten redirects by
+// default, and the pin only covers the hostname the caller validated, so a
+// public server answering 302 Location: http://169.254.169.254/... would
+// otherwise be dialed straight through, unchecked and unpinned. Each hop is
+// therefore passed through AssertURLSafe and its resolved IP added to the
+// pin table before the client follows it. Callers that need a different
+// policy (e.g. refusing redirects outright) still override CheckRedirect.
 var PinnedHTTPClient = func(hostname, resolvedIP string, timeout time.Duration) *http.Client {
+	pins := &pinTable{ips: map[string]string{}}
+	pins.set(hostname, resolvedIP)
 	dialer := &net.Dialer{
 		Timeout:   timeout,
 		KeepAlive: 30 * time.Second,
@@ -258,8 +295,10 @@ var PinnedHTTPClient = func(hostname, resolvedIP string, timeout time.Duration) 
 		Proxy: nil,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			host, port, splitErr := net.SplitHostPort(addr)
-			if splitErr == nil && host == hostname && resolvedIP != "" {
-				return dialer.DialContext(ctx, network, net.JoinHostPort(resolvedIP, port))
+			if splitErr == nil {
+				if ip, ok := pins.get(host); ok {
+					return dialer.DialContext(ctx, network, net.JoinHostPort(ip, port))
+				}
 			}
 			return dialer.DialContext(ctx, network, addr)
 		},
@@ -271,5 +310,16 @@ var PinnedHTTPClient = func(hostname, resolvedIP string, timeout time.Duration) 
 	return &http.Client{
 		Transport: transport,
 		Timeout:   timeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxPinnedRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxPinnedRedirects)
+			}
+			host, ip, err := AssertURLSafe(req.URL.String())
+			if err != nil {
+				return fmt.Errorf("redirect to %s blocked: %w", req.URL.Redacted(), err)
+			}
+			pins.set(host, ip)
+			return nil
+		},
 	}
 }

--- a/internal/utility/ssrf_test.go
+++ b/internal/utility/ssrf_test.go
@@ -283,3 +283,47 @@ func TestPinnedHTTPClientFollowsValidatedRedirectsPinned(t *testing.T) {
 		t.Fatalf("expected the redirect target body, got %q", body)
 	}
 }
+
+
+// TestPinnedHTTPClientRefusesHTTPSToHTTPDowngrade: a redirect from an https
+// origin to an http target must be refused before any validation, so headers
+// such as Authorization are never replayed over cleartext.
+func TestPinnedHTTPClientRefusesHTTPSToHTTPDowngrade(t *testing.T) {
+	origAssert := AssertURLSafe
+	defer func() { AssertURLSafe = origAssert }()
+	assertCalled := false
+	AssertURLSafe = func(rawURL string) (string, string, error) {
+		assertCalled = true
+		return "public.stub", "127.0.0.1", nil
+	}
+
+	client := PinnedHTTPClient("public.stub", "127.0.0.1", 5*time.Second)
+
+	first, err := http.NewRequest(http.MethodGet, "https://public.stub/login", nil)
+	if err != nil {
+		t.Fatalf("build origin request: %v", err)
+	}
+	first.Header.Set("Authorization", "Bearer secret")
+	next, err := http.NewRequest(http.MethodGet, "http://public.stub/login", nil)
+	if err != nil {
+		t.Fatalf("build redirect request: %v", err)
+	}
+	next.Header.Set("Authorization", "Bearer secret")
+
+	err = client.CheckRedirect(next, []*http.Request{first})
+	if err == nil || !strings.Contains(err.Error(), "downgrade") {
+		t.Fatalf("https->http redirect must be refused, got err=%v", err)
+	}
+	if assertCalled {
+		t.Fatalf("the downgrade must be rejected before the target is validated or pinned")
+	}
+
+	// The same hop staying on https is still validated and allowed.
+	same, _ := http.NewRequest(http.MethodGet, "https://public.stub/next", nil)
+	if err := client.CheckRedirect(same, []*http.Request{first}); err != nil {
+		t.Fatalf("https->https redirect should be allowed, got %v", err)
+	}
+	if !assertCalled {
+		t.Fatalf("an allowed hop must go through AssertURLSafe")
+	}
+}

--- a/internal/utility/ssrf_test.go
+++ b/internal/utility/ssrf_test.go
@@ -284,7 +284,6 @@ func TestPinnedHTTPClientFollowsValidatedRedirectsPinned(t *testing.T) {
 	}
 }
 
-
 // TestPinnedHTTPClientRefusesHTTPSToHTTPDowngrade: a redirect from an https
 // origin to an http target must be refused before any validation, so headers
 // such as Authorization are never replayed over cleartext.

--- a/internal/utility/ssrf_test.go
+++ b/internal/utility/ssrf_test.go
@@ -17,8 +17,14 @@
 package utility
 
 import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAssertURLSafe(t *testing.T) {
@@ -196,3 +202,84 @@ func TestAssertURLSafe(t *testing.T) {
 type mockErr struct{ s string }
 
 func (e *mockErr) Error() string { return e.s }
+
+// TestPinnedHTTPClientRevalidatesRedirects: the pin only covers the hostname
+// AssertURLSafe validated. A redirect to any other host must go through the
+// same guard (and be pinned in turn), otherwise an attacker-controlled public
+// server can 302 the client onto loopback, link-local or RFC1918 targets.
+func TestPinnedHTTPClientRevalidatesRedirects(t *testing.T) {
+	origLookup := LookupHost
+	defer func() { LookupHost = origLookup }()
+	// Every hostname resolves to loopback: the redirect target must then be
+	// rejected as non-public by AssertURLSafe.
+	LookupHost = func(host string) ([]string, error) { return []string{"127.0.0.1"}, nil }
+
+	internalHit := false
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		internalHit = true
+		_, _ = w.Write([]byte("secret"))
+	}))
+	defer internal.Close()
+
+	public := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL+"/latest/meta-data/", http.StatusFound)
+	}))
+	defer public.Close()
+
+	_, publicPort, err := net.SplitHostPort(strings.TrimPrefix(public.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split public addr: %v", err)
+	}
+	// "public.stub" stands in for a hostname AssertURLSafe accepted and pinned.
+	client := PinnedHTTPClient("public.stub", "127.0.0.1", 5*time.Second)
+
+	resp, err := client.Get("http://public.stub:" + publicPort + "/")
+	if err == nil {
+		resp.Body.Close()
+	}
+	if internalHit {
+		t.Fatalf("redirect target on a non-public address was fetched; the SSRF guard was bypassed")
+	}
+	if err == nil || !strings.Contains(err.Error(), "non-public address") {
+		t.Fatalf("expected the redirect to be rejected as non-public, got err=%v", err)
+	}
+}
+
+// A redirect to a host that passes the guard is followed, and the new hop is
+// dialed through its own pin rather than a fresh DNS lookup.
+func TestPinnedHTTPClientFollowsValidatedRedirectsPinned(t *testing.T) {
+	origAssert := AssertURLSafe
+	defer func() { AssertURLSafe = origAssert }()
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("landed"))
+	}))
+	defer target.Close()
+	_, targetPort, _ := net.SplitHostPort(strings.TrimPrefix(target.URL, "http://"))
+
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Redirect to a hostname that only the pin table can resolve.
+		http.Redirect(w, r, "http://second.stub:"+targetPort+"/", http.StatusFound)
+	}))
+	defer first.Close()
+	_, firstPort, _ := net.SplitHostPort(strings.TrimPrefix(first.URL, "http://"))
+
+	AssertURLSafe = func(rawURL string) (string, string, error) {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			return "", "", err
+		}
+		return u.Hostname(), "127.0.0.1", nil
+	}
+
+	client := PinnedHTTPClient("first.stub", "127.0.0.1", 5*time.Second)
+	resp, err := client.Get("http://first.stub:" + firstPort + "/")
+	if err != nil {
+		t.Fatalf("validated redirect should be followed: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "landed" {
+		t.Fatalf("expected the redirect target body, got %q", body)
+	}
+}


### PR DESCRIPTION
### Summary

Fixes #19544

`utility.PinnedHTTPClient` pinned dials only for the hostname the caller had validated with `AssertURLSafe` and left `http.Client`'s default redirect following in place, so a validated public URL that answered `302 Location: http://169.254.169.254/...` (or any loopback / RFC1918 target) was dialed on the next hop with no check and no pin. The MCP tool-discovery client (`POST /api/v1/mcp/servers/:id/test`, `FetchTools`), the MCP tool-call client used during agent runs, and the github/gitlab/bitbucket/teams/salesforce connectors use the client as-is; `upload.go`, `invoke.go` and `sitemap.go` had each re-implemented redirect handling to avoid this.

Changes:
- `PinnedHTTPClient` now installs a `CheckRedirect` that keeps net/http's ten-redirect budget, runs every hop through `AssertURLSafe`, and records the hop's resolved IP in a per-client pin table; `DialContext` consults that table, so a validated redirect is followed pinned and a non-public one is refused with the guard's error. Callers that override `CheckRedirect` (`upload.go`, `invoke.go`, `sitemap.go`, the jira/seafile/moodle/rest_api connectors) keep their policy unchanged.

Tests:
- `TestPinnedHTTPClientRevalidatesRedirects`: a loopback server standing in for the validated host redirects to a second loopback server; on `main` the second server is fetched (the test reports "the SSRF guard was bypassed"), with this change the client returns the guard's `non-public address` error and the second server is never hit.
- `TestPinnedHTTPClientFollowsValidatedRedirectsPinned`: a redirect to a hostname that only the pin table can resolve is followed and lands on the pinned server, showing validated hops still work and are dialed through the pin rather than DNS.
- `CGO_ENABLED=0 go test ./internal/utility/ ./internal/syncer/connector/ ./internal/agent/component/`, `go vet ./internal/utility/` and `gofmt` pass locally.

Written with the help of an AI coding agent (Claude Code); reviewed by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcXuE1qS3V3CL2AbMpsMk3
