### PR TITLE
fix: add tenant ownership check to get_document_image endpoint

### DIFF
--- a/api/apps/restful_apis/document_api.py
+++ b/api/apps/restful_apis/document_api.py
@@ -1857,6 +1857,8 @@ async def get_document_image(image_id):
         if not parsed:
             return get_data_error_result(message="Image not found.")
         bkt, nm = parsed
+        if not KnowledgebaseService.accessible(kb_id=bkt, user_id=current_user.id):
+            return get_data_error_result(message="Image not found.")
         data = await thread_pool_exec(settings.STORAGE_IMPL.get, bkt, nm)
         if not data:
             return get_data_error_result(message="Image not found.")


### PR DESCRIPTION
## Fix: add tenant ownership check to `get_document_image` endpoint

### Problem

`GET /api/v1/documents/images/{dataset_id}-{object_key}` reads from arbitrary storage buckets without verifying that the caller owns or has access to the target dataset. Any authenticated user can read original uploaded documents (not just thumbnails) from any tenant by constructing the composite path id.

Reported in #19428 and #15959.

### Fix

Adds a `KnowledgebaseService.accessible()` check before the storage read, using the same pattern as the dataset-list and document-list handlers in this file (lines 342, 393). Returns the same "Image not found." message as `preview` for anti-enumeration consistency.

### Testing

- Verified that the check runs before the storage read on the patched file
- Verified that the existing dataset-list and document-list handlers use the identical `accessible()` pattern in this codebase
- The check covers: dataset existence (anti-enumeration), owner match (`kb.tenant_id == user_id`), and team sharing (`TenantPermission.TEAM` via joined tenants)

### Notes

- This is a minimal 2-line fix targeting only the images route. The `/thumbnails` route (also flagged in #19428) would need a separate per-doc-id check and could be a follow-up.
- References: #19428, #15959, #14763
