### PR TITLE
fix(rag): assign PDF parser tables to tbls in book chunking method (#19557)

### DIFF
--- a/rag/app/book.py
+++ b/rag/app/book.py
@@ -126,6 +126,8 @@ def chunk(filename, binary=None, from_page=0, to_page=MAXIMUM_PAGE_NUMBER, lang=
             **kwargs,
         )
 
+        tbls = tables
+
         if not sections and not tables:
             return []
 


### PR DESCRIPTION
### Summary of Changes
Fixes #19557

In `rag/app/book.py`, the PDF parsing branch receives `(sections, tables, pdf_parser)` from `parser(...)`, but previously omitted assigning `tables` to `tbls`. As a result, `tbls` remained `[]` and `tokenize_table(tbls, ...)` silently dropped all figure, table, and formula chunks for PDF documents using the `book` chunking method.

### Changes Made:
- Assigned `tbls = tables` following the PDF parser invocation in `rag/app/book.py`.
- Verified that `tokenize_table(tbls, ...)` properly emits table and image chunks for PDF inputs with DeepDOC and other layout parsers.

### Verification:
- Chunked a sample PDF with figures/tables using `book` chunk method and verified non-zero `doc_type_kwd` in `{"table", "image"}` chunks are preserved.