### PR TITLE
feat: add AnonRouter model provider

### DIFF
--- a/conf/llm_factories.json
+++ b/conf/llm_factories.json
@@ -1,6 +1,13 @@
 {
     "factory_llm_infos": [
         {
+            "name": "AnonRouter",
+            "logo": "",
+            "tags": "LLM",
+            "status": "1",
+            "llm": []
+        },
+        {
             "name": "Synthorai",
             "logo": "",
             "tags": "LLM",

--- a/conf/models/anonrouter.json
+++ b/conf/models/anonrouter.json
@@ -1,0 +1,550 @@
+{
+  "name": "AnonRouter",
+  "url": {
+    "default": "https://api.anonrouter.ai/v1"
+  },
+  "url_suffix": {
+    "chat": "chat/completions",
+    "models": "models"
+  },
+  "class": "anonrouter",
+  "models": [
+    {
+      "name": "anthropic/claude-fable-5",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "anthropic/claude-haiku-4-5",
+      "context_length": 200000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "anthropic/claude-opus-5",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "anthropic/claude-sonnet-5",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v3",
+      "context_length": 163840,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v3-0324",
+      "context_length": 163840,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v3.1",
+      "context_length": 163840,
+      "max_output": 32768,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v3.2",
+      "context_length": 163840,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v4-flash",
+      "context_length": 1048576,
+      "max_output": 32768,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v4-flash-0731",
+      "context_length": 1048576,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v4-flash-vision-exp",
+      "context_length": 1048576,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v4-pro",
+      "context_length": 1048576,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "deepseek/deepseek-v4-pro-0813",
+      "context_length": 1048576,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-2.5-flash",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-2.5-pro",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3-flash-preview",
+      "context_length": 256000,
+      "max_output": 65536,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.1-flash-lite",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.1-pro-preview",
+      "context_length": 1000000,
+      "max_output": 32768,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.5-flash",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.5-flash-lite",
+      "context_length": 1000000,
+      "max_output": 65536,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.6-flash",
+      "context_length": 1000000,
+      "max_output": 65536,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.7-flash",
+      "context_length": 1000000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemini-3.8-flash",
+      "context_length": 1000000,
+      "max_output": 65536,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "google/gemma-4-26b-a4b-it",
+      "context_length": 262144,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "inclusionai/ling-3.0-flash-fin",
+      "context_length": 262144,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "moonshotai/kimi-k2.5",
+      "context_length": 256000,
+      "max_output": 65536,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "moonshotai/kimi-k2.6",
+      "context_length": 262144,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "moonshotai/kimi-k2.7-code",
+      "context_length": 262144,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "moonshotai/kimi-k3",
+      "context_length": 262144,
+      "max_output": 32768,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "nvidia/nemotron-3-nano-30b-a3b",
+      "context_length": 262144,
+      "max_output": 228000,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-4o",
+      "context_length": 128000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-4o-mini",
+      "context_length": 128000,
+      "max_output": 16384,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.2",
+      "context_length": 256000,
+      "max_output": 65536,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.2-codex",
+      "context_length": 256000,
+      "max_output": 65536,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.3-codex",
+      "context_length": 400000,
+      "max_output": 128000,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.4",
+      "context_length": 1000000,
+      "max_output": 131072,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.4-mini",
+      "context_length": 400000,
+      "max_output": 128000,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.4-pro",
+      "context_length": 1000000,
+      "max_output": 128000,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.5",
+      "context_length": 1000000,
+      "max_output": 131072,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.5-pro",
+      "context_length": 1000000,
+      "max_output": 128000,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-5.6-terra",
+      "context_length": 1000000,
+      "max_output": 128000,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-6-astra",
+      "context_length": 1050000,
+      "max_output": 128000,
+      "model_types": [
+        "chat",
+        "vision"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-oss-120b",
+      "context_length": 131072,
+      "max_output": 32768,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "openai/gpt-oss-20b",
+      "context_length": 131072,
+      "max_output": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "tencent/hy3",
+      "context_length": 262144,
+      "max_output": 131072,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    },
+    {
+      "name": "xiaomi/mimo-v2.5-pro",
+      "context_length": 1048576,
+      "max_output": 16384,
+      "model_types": [
+        "chat"
+      ],
+      "tools": {
+        "support": true
+      }
+    }
+  ]
+}

--- a/docs/guides/models/supported_models.mdx
+++ b/docs/guides/models/supported_models.mdx
@@ -21,6 +21,7 @@ A complete list of model providers supported by RAGFlow, which will continue to 
 | --- | --- |
 | 302.AI | `https://302.ai` |
 | aimlapi.com | `https://aimlapi.com` |
+| AnonRouter | `https://anonrouter.ai` |
 | Anthropic | `https://www.anthropic.com` |
 | Astraflow | `https://astraflow.ucloud-global.com/en-us` |
 | Astraflow-CN | `https://astraflow.ucloud.cn/` |

--- a/internal/entity/models/anonrouter.go
+++ b/internal/entity/models/anonrouter.go
@@ -1,0 +1,41 @@
+//
+//  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+package models
+
+// AnonRouterModel drives AnonRouter, a hosted gateway that relays models from
+// several labs behind one OpenAI-compatible endpoint, so the embedded
+// OpenAIAPICompatibleModel covers every call.
+type AnonRouterModel struct {
+	*OpenAIAPICompatibleModel
+}
+
+// NewAnonRouterModel creates an AnonRouter driver.
+func NewAnonRouterModel(baseURL map[string]string, urlSuffix URLSuffix) *AnonRouterModel {
+	return &AnonRouterModel{
+		OpenAIAPICompatibleModel: NewOpenAIAPICompatibleModel(baseURL, urlSuffix),
+	}
+}
+
+// Name returns the driver name.
+func (m *AnonRouterModel) Name() string {
+	return "anonrouter"
+}
+
+// NewInstance returns a driver bound to the given base URL.
+func (m *AnonRouterModel) NewInstance(baseURL map[string]string) ModelDriver {
+	return NewAnonRouterModel(baseURL, m.baseModel.URLSuffix)
+}

--- a/internal/entity/models/anonrouter_test.go
+++ b/internal/entity/models/anonrouter_test.go
@@ -1,0 +1,171 @@
+package models
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"ragflow/internal/common"
+	"testing"
+)
+
+var anonRouterTestAPIKey = "sk-anon-test"
+
+func newAnonRouterForTest(baseURL string) *AnonRouterModel {
+	return NewAnonRouterModel(
+		map[string]string{"default": baseURL},
+		URLSuffix{Chat: "chat/completions", Models: "models"},
+	)
+}
+
+func TestAnonRouterName(t *testing.T) {
+	if got := newAnonRouterForTest("http://unused").Name(); got != "anonrouter" {
+		t.Errorf("Name()=%q", got)
+	}
+}
+
+func TestAnonRouterFactory(t *testing.T) {
+	driver, err := NewModelFactory().CreateModelDriver("anonrouter", map[string]string{"default": "http://unused"}, URLSuffix{})
+	if err != nil {
+		t.Fatalf("CreateModelDriver: %v", err)
+	}
+	if _, ok := driver.(*AnonRouterModel); !ok {
+		t.Fatalf("driver type=%T, want *AnonRouterModel", driver)
+	}
+	if _, ok := driver.NewInstance(map[string]string{"default": "http://other"}).(*AnonRouterModel); !ok {
+		t.Fatal("NewInstance did not return *AnonRouterModel")
+	}
+}
+
+// AnonRouter is a hosted gateway, so unlike a local server it must receive the
+// tenant's key as a bearer token on every call.
+func TestAnonRouterChatSendsAPIKey(t *testing.T) {
+	withSSRFBypass(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-anon-test" {
+			t.Errorf("Authorization=%q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chat-anonrouter",
+			"choices": []map[string]any{{"message": map[string]any{"content": "pong"}}},
+			"usage":   map[string]any{"prompt_tokens": 3, "completion_tokens": 5, "total_tokens": 8},
+		})
+	}))
+	defer srv.Close()
+
+	usage := &common.ModelUsage{}
+	resp, err := newAnonRouterForTest(srv.URL).ChatWithMessages(
+		t.Context(),
+		"anthropic/claude-sonnet-5",
+		[]Message{{Role: "user", Content: "ping"}},
+		&APIConfig{ApiKey: &anonRouterTestAPIKey},
+		nil,
+		usage,
+	)
+	if err != nil {
+		t.Fatalf("ChatWithMessages: %v", err)
+	}
+	if *resp.Answer != "pong" {
+		t.Errorf("Answer=%q", *resp.Answer)
+	}
+	assertModelUsage(t, usage, 3, 5, 8)
+}
+
+func TestAnonRouterListModelsAndCheckConnection(t *testing.T) {
+	withSSRFBypass(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/models" {
+			t.Errorf("%s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-anon-test" {
+			t.Errorf("Authorization=%q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "anthropic/claude-sonnet-5"},
+				{"id": "openai/gpt-6-astra"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	model := newAnonRouterForTest(srv.URL)
+	list, err := model.ListModels(t.Context(), &APIConfig{ApiKey: &anonRouterTestAPIKey})
+	if err != nil {
+		t.Fatalf("ListModels: %v", err)
+	}
+	if joinModelNames(list, ",") != "anthropic/claude-sonnet-5,openai/gpt-6-astra" {
+		t.Errorf("models=%v", list)
+	}
+	if err := model.CheckConnection(t.Context(), &APIConfig{ApiKey: &anonRouterTestAPIKey}); err != nil {
+		t.Fatalf("CheckConnection: %v", err)
+	}
+}
+
+// The shipped config must resolve to the AnonRouter driver and the pinned
+// gateway endpoint.
+func TestAnonRouterProviderConfig(t *testing.T) {
+	dir, restore := setupProviderTestDir(t, "anonrouter.json")
+	defer restore()
+
+	if err := InitProviderManager(dir); err != nil {
+		t.Fatalf("InitProviderManager: %v", err)
+	}
+
+	provider := GetProviderManager().FindProvider("AnonRouter")
+	if provider == nil {
+		t.Fatal("AnonRouter provider not found")
+	}
+	if _, ok := provider.ModelDriver.(*AnonRouterModel); !ok {
+		t.Fatalf("ModelDriver=%T, want *models.AnonRouterModel", provider.ModelDriver)
+	}
+	if got := provider.URL["default"]; got != "https://api.anonrouter.ai/v1" {
+		t.Errorf("default URL=%q", got)
+	}
+	if provider.URLSuffix.Chat != "chat/completions" || provider.URLSuffix.Models != "models" {
+		t.Errorf("URLSuffix=%+v", provider.URLSuffix)
+	}
+	if len(provider.Models) == 0 {
+		t.Fatal("no models declared")
+	}
+
+	// AnonRouter relays text-generation models only; the multimodal ones carry
+	// the extra "vision" type, and every entry must declare both token limits
+	// and tool support.
+	vision := map[string]bool{}
+	for _, model := range provider.Models {
+		switch {
+		case len(model.ModelTypes) == 1 && model.ModelTypes[0] == "chat":
+		case len(model.ModelTypes) == 2 && model.ModelTypes[0] == "chat" && model.ModelTypes[1] == "vision":
+			vision[model.Name] = true
+		default:
+			t.Errorf("%s model_types=%v, want [chat] or [chat vision]", model.Name, model.ModelTypes)
+		}
+		if model.ContextLength == nil || model.MaxOutput == nil {
+			t.Errorf("%s missing context_length/max_output", model.Name)
+		} else if *model.MaxOutput > *model.ContextLength {
+			t.Errorf("%s max_output %d exceeds context_length %d", model.Name, *model.MaxOutput, *model.ContextLength)
+		}
+		if model.Tools == nil || !model.Tools.Support {
+			t.Errorf("%s does not declare tool support", model.Name)
+		}
+		if model.Thinking != nil {
+			t.Errorf("%s declares thinking metadata; AnonRouter reasoning is not on the thinking wire", model.Name)
+		}
+	}
+
+	// Guard both sides of the split against a catalogue edit that drops the
+	// vision type wholesale or applies it to every entry.
+	for _, name := range []string{"anthropic/claude-sonnet-5", "google/gemini-3.8-flash", "openai/gpt-6-astra"} {
+		if !vision[name] {
+			t.Errorf("%s should declare vision", name)
+		}
+	}
+	for _, name := range []string{"deepseek/deepseek-v4-pro", "openai/gpt-oss-120b", "tencent/hy3"} {
+		if vision[name] {
+			t.Errorf("%s should not declare vision", name)
+		}
+	}
+}

--- a/internal/entity/models/factory.go
+++ b/internal/entity/models/factory.go
@@ -171,6 +171,8 @@ func (f *ModelFactory) CreateModelDriver(providerName string, baseURL map[string
 		return NewGreenPTModel(baseURL, urlSuffix), nil
 	case "synthorai":
 		return NewSynthoraiModel(baseURL, urlSuffix), nil
+	case "anonrouter":
+		return NewAnonRouterModel(baseURL, urlSuffix), nil
 	default:
 		return NewDummyModel(baseURL, urlSuffix), nil
 	}

--- a/rag/llm/chat_model.py
+++ b/rag/llm/chat_model.py
@@ -2087,6 +2087,23 @@ class SynthoraiChat(Base):
         super().__init__(key, model_name, self._BASE_URL, **kwargs)
 
 
+class AnonRouterChat(Base):
+    """AnonRouter OpenAI-compatible chat adapter.
+
+    The endpoint is fixed rather than configurable. AnonRouter is a hosted
+    gateway on one known host, so a tenant-supplied ``base_url`` would have no
+    legitimate use and would send the AnonRouter API key to whatever host was
+    configured.
+    """
+
+    _FACTORY_NAME = "AnonRouter"
+
+    _BASE_URL = "https://api.anonrouter.ai/v1"
+
+    def __init__(self, key, model_name, base_url=None, **kwargs):
+        super().__init__(key, model_name, self._BASE_URL, **kwargs)
+
+
 class LiteLLMBase(ABC):
     _FACTORY_NAME = [
         "Tongyi-Qianwen",

--- a/rag/llm/cv_model.py
+++ b/rag/llm/cv_model.py
@@ -688,6 +688,17 @@ class SILICONFLOWCV(GptV4):
         super().__init__(key, model_name, lang, base_url, **kwargs)
 
 
+class AnonRouterCV(GptV4):
+    """AnonRouter vision adapter bound to the hosted compatibility endpoint."""
+
+    _FACTORY_NAME = "AnonRouter"
+
+    _BASE_URL = "https://api.anonrouter.ai/v1"
+
+    def __init__(self, key, model_name, lang="Chinese", base_url=None, **kwargs):
+        super().__init__(key, model_name, lang, self._BASE_URL, **kwargs)
+
+
 class OpenRouterCV(GptV4):
     _FACTORY_NAME = "OpenRouter"
 

--- a/rag/llm/model_meta.py
+++ b/rag/llm/model_meta.py
@@ -1149,6 +1149,25 @@ class Hubris(OpenAIAPICompatible):
         return f"{self._BASE_URL}/models"
 
 
+class AnonRouter(OpenAIAPICompatible):
+    """AnonRouter model metadata.
+
+    ``_get_model_list_url`` is pinned for the same reason the chat class pins
+    its endpoint: the catalogue must be read from the gateway itself, never
+    from a host supplied by the tenant. The listing is served in OpenAI format
+    and requires the tenant's bearer key, which ``Base._get_raw_model_list``
+    already sends.
+    """
+
+    _FACTORY_NAME = "AnonRouter"
+
+    _BASE_URL = "https://api.anonrouter.ai/v1"
+
+    def _get_model_list_url(self):
+        """Return the catalogue URL, ignoring any tenant-configured base URL."""
+        return f"{self._BASE_URL}/models"
+
+
 class NewAPI(OpenAIAPICompatible):
     _FACTORY_NAME = "New API"
 

--- a/test/unit_test/rag/llm/test_anonrouter_provider.py
+++ b/test/unit_test/rag/llm/test_anonrouter_provider.py
@@ -1,0 +1,85 @@
+#
+#  Copyright 2026 The InfiniFlow Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import pytest
+
+from common.constants import LLMType
+from rag.llm.chat_model import AnonRouterChat
+from rag.llm.cv_model import AnonRouterCV
+from rag.llm.model_meta import AnonRouter
+
+pytestmark = pytest.mark.p2
+
+BASE_URL = "https://api.anonrouter.ai/v1"
+
+
+def test_anonrouter_chat_pins_the_gateway_endpoint():
+    # A tenant-supplied base_url must not redirect the tenant's key elsewhere.
+    chat = AnonRouterChat("sk-test", "anthropic/claude-sonnet-5", base_url="https://attacker.example/v1")
+
+    assert chat.base_url == BASE_URL
+    assert str(chat.client.base_url).rstrip("/") == BASE_URL
+    assert str(chat.async_client.base_url).rstrip("/") == BASE_URL
+
+
+def test_anonrouter_chat_defaults_to_the_gateway_endpoint():
+    chat = AnonRouterChat("sk-test", "openai/gpt-6-astra")
+
+    assert chat.base_url == BASE_URL
+    assert chat.model_name == "openai/gpt-6-astra"
+
+
+def test_anonrouter_cv_pins_the_gateway_endpoint():
+    cv = AnonRouterCV(
+        "sk-test",
+        "google/gemini-2.5-flash",
+        base_url="https://attacker.example/v1",
+    )
+
+    assert cv.base_url == BASE_URL
+    assert str(cv.client.base_url).rstrip("/") == BASE_URL
+    assert str(cv.async_client.base_url).rstrip("/") == BASE_URL
+
+
+def test_anonrouter_model_list_url_is_pinned():
+    assert AnonRouter(api_key="sk-test", base_url=None)._get_model_list_url() == f"{BASE_URL}/models"
+    assert AnonRouter(api_key="sk-test", base_url="https://attacker.example/v1")._get_model_list_url() == f"{BASE_URL}/models"
+
+
+def test_anonrouter_formats_openai_format_catalogue():
+    provider = AnonRouter(api_key="sk-test", base_url=None)
+
+    models = provider._format_model_list(
+        {
+            "object": "list",
+            "data": [
+                {"id": "anthropic/claude-sonnet-5", "object": "model"},
+                {"id": "deepseek/deepseek-v4-pro", "object": "model"},
+                {"object": "model"},
+            ],
+        }
+    )
+
+    assert models == [
+        {"name": "anthropic/claude-sonnet-5", "model_types": [LLMType.CHAT.value], "features": [], "max_tokens": 8192},
+        {"name": "deepseek/deepseek-v4-pro", "model_types": [LLMType.CHAT.value], "features": [], "max_tokens": 8192},
+    ]
+
+
+def test_anonrouter_classes_share_the_factory_name():
+    assert AnonRouterChat._FACTORY_NAME == "AnonRouter"
+    assert AnonRouterCV._FACTORY_NAME == "AnonRouter"
+    assert AnonRouter._FACTORY_NAME == "AnonRouter"


### PR DESCRIPTION
### Summary

I maintain AnonRouter and added it as a hosted OpenAI-compatible model provider, following RAGFlow's existing Hubris and Synthorai provider patterns.

This adds:

- the fixed `https://api.anonrouter.ai/v1` endpoint for chat and authenticated model discovery;
- 46 currently supported model definitions, including context/output limits, tool support, and vision capability metadata;
- Python chat/vision and Go provider registration using the existing generic OpenAI-compatible implementations;
- focused Python and Go tests, plus the supported-models documentation entry.

The model IDs and capabilities were checked against AnonRouter's authenticated `/v1/models` response on 2026-09-11. The provider-specific classes only bind the hosted endpoint and factory identity; chat, vision, streaming, and tool calling remain on RAGFlow's shared OpenAI-compatible paths.

Validation performed:

- `uv run pytest test/unit_test/rag/llm/test_anonrouter_provider.py -q` — 6 passed
- `uvx ruff check test/unit_test/rag/llm/test_anonrouter_provider.py`
- `uvx ruff format --check rag/llm/chat_model.py rag/llm/cv_model.py rag/llm/model_meta.py test/unit_test/rag/llm/test_anonrouter_provider.py`
- JSON validation, `gofmt` verification, and `git diff --check`

The package-scoped Go unit suite was not runnable on this macOS/arm64 host because RAGFlow's `build.sh --test` requires its Linux native CGO libraries; the Go tests are included for upstream CI.
