### PR TITLE
fix(model): delete provider models and instances in one transaction

### DIFF
--- a/internal/service/model_service.go
+++ b/internal/service/model_service.go
@@ -2215,13 +2215,21 @@ func (m *ModelProviderService) DropProviderInstances(ctx context.Context, provid
 		return common.CodeNotFound, fmt.Errorf("no instance found for provider %q and instances %q", providerIDOrName, notExistInstances)
 	}
 
-	// Second pass: delete models and instances by IDs.
+	// Second pass: delete models and instances by IDs atomically.
 	// Mirrors Python's: delete_models_by_instance_ids(instance_ids)
 	//                   TenantModelInstanceService.delete_by_ids(instance_ids)
-	if _, err = m.modelDAO.DeleteByInstanceIDs(ctx, dao.DB, instanceIDs); err != nil {
-		return common.CodeServerError, err
-	}
-	if _, err = m.modelInstanceDAO.DeleteByIDs(ctx, dao.DB, instanceIDs); err != nil {
+	// Both deletes share one transaction so a failure of the instance delete
+	// cannot leave the tenant models already removed (partial deletion).
+	err = dao.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if _, err := m.modelDAO.DeleteByInstanceIDs(ctx, tx, instanceIDs); err != nil {
+			return err
+		}
+		if _, err := m.modelInstanceDAO.DeleteByIDs(ctx, tx, instanceIDs); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
 		return common.CodeServerError, err
 	}
 

--- a/internal/service/model_service_test.go
+++ b/internal/service/model_service_test.go
@@ -1119,3 +1119,41 @@ func TestModelProviderServiceResolveModelToolSupportPropagatesLookupFailure(t *t
 		t.Errorf("model lookup failure = (%v, nil), want a propagated error", got)
 	}
 }
+
+func TestDropProviderInstancesRollsBackWhenInstanceDeleteFails(t *testing.T) {
+	db := setupModelProviderServiceTestDB(t)
+	useModelProviderServiceTestDB(t, db)
+	seedModelProviderServiceScope(t, db)
+
+	// Force the second delete (tenant_model_instance) to fail so the
+	// transaction must roll back the already-applied tenant_model delete.
+	if err := db.Callback().Delete().Before("gorm:DELETE").Register(
+		"test:fail_tenant_model_instance_delete",
+		func(tx *gorm.DB) {
+			if tx.Statement != nil && tx.Statement.Table == "tenant_model_instance" {
+				_ = tx.AddError(errors.New("forced tenant_model_instance delete failure"))
+			}
+		},
+	); err != nil {
+		t.Fatalf("failed to register failing delete callback: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Callback().Delete().Remove("test:fail_tenant_model_instance_delete")
+	})
+
+	code, err := NewModelProviderService().DropProviderInstances(t.Context(), "provider-1", "user-1", []string{"instance-1"})
+	if err == nil {
+		t.Fatalf("DropProviderInstances() error = nil, want forced instance delete failure")
+	}
+	if code != common.CodeServerError {
+		t.Fatalf("code = %v, want %v", code, common.CodeServerError)
+	}
+
+	var modelCount int64
+	if err := db.Model(&entity.TenantModel{}).Where("instance_id = ?", "instance-1").Count(&modelCount).Error; err != nil {
+		t.Fatalf("failed to count tenant models: %v", err)
+	}
+	if modelCount != 1 {
+		t.Fatalf("rollback must keep tenant models for the instance, got %d rows", modelCount)
+	}
+}


### PR DESCRIPTION
## Summary
- wrap the two deletes in `DropProviderInstances` (`modelDAO.DeleteByInstanceIDs` + `modelInstanceDAO.DeleteByIDs`) in a single gorm transaction, so a failure of the instance delete can no longer leave the tenant models already removed (partial provider deletion)
- add a regression test that forces the `tenant_model_instance` delete to fail and asserts the rollback keeps the tenant models

## Why
On current `main` the two deletes run independently. If the second delete fails, the models of the dropped instances are already gone while the instances remain, leaving an inconsistent provider state. The same non-transactional batch loop was flagged by the review bot on #14166 and #16180.

## Tests
- `go test ./internal/service/ -run TestDropProviderInstances` (new rollback case + existing model provider suites)