### PR TITLE
fix(file-commit): stop delete operations crashing the whole commit

### DIFF
--- a/api/db/services/file_commit_service.py
+++ b/api/db/services/file_commit_service.py
@@ -21,6 +21,7 @@ import json
 import logging
 from typing import Optional
 
+from api.db import FileType
 from api.db.db_models import DB, FileCommit, FileCommitItem, File, User
 from api.db.services.common_service import CommonService
 from api.db.services.file_service import FileService
@@ -371,8 +372,21 @@ class FileCommitService(CommonService):
                         item["old_location"] = old_location
 
                     # Remove the file record. The blob stays in the content-addressed object
-                    # store and the tree_state tombstone below keeps it reachable from history.
-                    File.delete().where(File.id == file_id).execute()
+                    # store, and history keeps its metadata in the tree_state tombstone below
+                    # rather than in the File row.
+                    #
+                    # Folders are exempt: _build_hierarchical_tree resolves sub-folder parentage
+                    # from live File rows, so dropping one makes every historical entry beneath it
+                    # unreachable. File entries are read from tree_state, so they are unaffected.
+                    row = File.get_or_none(File.id == file_id)
+                    if row is not None and row.type == FileType.FOLDER.value:
+                        logging.warning(
+                            "create_commit: refusing to delete folder %s in commit for %s",
+                            file_id,
+                            folder_id,
+                        )
+                    elif row is not None:
+                        File.delete().where(File.id == file_id).execute()
 
                     # Remove from tree state (mark deleted)
                     if file_id in tree_state:

--- a/api/db/services/file_commit_service.py
+++ b/api/db/services/file_commit_service.py
@@ -370,8 +370,9 @@ class FileCommitService(CommonService):
                         item["old_hash"] = old_hash
                         item["old_location"] = old_location
 
-                    # Soft-delete the file record
-                    File.update(status="0", update_time=current_timestamp()).where(File.id == file_id).execute()
+                    # Remove the file record. The blob stays in the content-addressed object
+                    # store and the tree_state tombstone below keeps it reachable from history.
+                    File.delete().where(File.id == file_id).execute()
 
                     # Remove from tree state (mark deleted)
                     if file_id in tree_state:

--- a/api/db/services/file_commit_service.py
+++ b/api/db/services/file_commit_service.py
@@ -380,12 +380,16 @@ class FileCommitService(CommonService):
                     # unreachable. File entries are read from tree_state, so they are unaffected.
                     row = File.get_or_none(File.id == file_id)
                     if row is not None and row.type == FileType.FOLDER.value:
+                        # Drop the whole change, not just the delete: recording the tombstone and
+                        # the commit item below would leave history calling the folder deleted
+                        # while its row is still there.
                         logging.warning(
                             "create_commit: refusing to delete folder %s in commit for %s",
                             file_id,
                             folder_id,
                         )
-                    elif row is not None:
+                        continue
+                    if row is not None:
                         File.delete().where(File.id == file_id).execute()
 
                     # Remove from tree state (mark deleted)


### PR DESCRIPTION
Continues #18929, which could not be reopened. Details at the bottom.

### Summary

`create_commit`'s delete branch writes a column the model does not have. On current main, `api/db/services/file_commit_service.py:373`:

```python
# Soft-delete the file record
File.update(status="0", update_time=current_timestamp()).where(File.id == file_id).execute()
```

`File` in `api/db/db_models.py` declares `id, parent_id, tenant_id, created_by, name, location, size, type, source_type`. There is no `status`, and no migration adds one. peewee's `Model._normalize_data` falls back to `getattr(cls, key)` for an unrecognised keyword, so this raises while the statement is being built.

It happens inside the surrounding `with DB.atomic()`, so the `FileCommit` row and every add or modify item batched in the same commit roll back. The route returns 500. Blobs already `put()` to storage are not rolled back, so they are orphaned.

This is the payload documented in `docs/references/http_api_reference.md`:

```
POST /api/v1/workspaces/<folder_id>/commits
{"message":"rm","files":[{"file_id":"f1","file_name":"a.txt","operation":"delete"}]}
```

### Why the suite was green

`test/testcases/restful_api/test_file_commit_routes_unit.py` declared its own `File` double with a column the real model lacks:

```python
status = CharField(max_length=1, null=True, default="1", index=True)
```

so `test_create_commit_delete` asserted `code == 0` against a schema production does not have. The same harness built `FileType` from plain strings while `api/db` defines it as a `StrEnum`, so reading `.value` from a member raised.

This branch makes both doubles mirror the modules they stand in for. With the schema corrected the delete test reproduces the production failure rather than passing over it:

```
test_create_commit_delete
res = {'code': 500, 'data': None, 'message': "type object 'FileTestModel' has no attribute 'status'"}
```

Red against main's service file, green at this head, with the swapped file's blob hash checked against `upstream/main` before each run:

```
service file from main:  2 failed, 19 passed
service file at this head: 21 passed
```

### Why remove the row rather than add the column

Line 374 is the only writer of a `File` status in the tree and nothing reads one. `get_by_pf_id` does not filter on it, so the soft delete could never have become visible in the workspace listing. Removing the row matches `FileService.delete` and `delete_by_pf_id`, and the `tree_state` entry written immediately below still records the tombstone, so history stays intact.

If you would rather keep the soft-delete intent, the alternative is adding `status` to the `File` model plus an `alter_db_add_column` migration. Happy to switch. That path also needs the listing query to filter on it, or deleted files keep showing up.

### Folders are exempt

`_build_hierarchical_tree` reads file entries from `tree_state`, so a deleted file keeps its name, hash, size and parent and reconstruction is unaffected. It resolves sub-folder parentage from live `File` rows, so dropping a folder row makes every historical entry beneath it unreachable.

A folder delete is therefore refused, and the whole change is dropped rather than only the row removal. Recording the tombstone and the commit item while leaving the row in place would have history call the folder deleted when it is not, which is the same drift the guard exists to prevent. A test covers it.

### On #18929

I was asked to reopen it. GitHub refuses the reopen with "Could not open the pull request" from both the API and the CLI, and a closed pull request does not pick up new pushes to its branch, so its view is frozen at the old head and still shows the stale base. Same branch, same commits, refreshed onto current main, plus the test work above.
